### PR TITLE
swev-id: matplotlib__matplotlib-13989 preserve Axes.hist range when density

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6686,7 +6686,7 @@ optional.
 
         density = bool(density) or bool(normed)
         if density and not stacked:
-            hist_kwargs = dict(density=density)
+            hist_kwargs['density'] = density
 
         # List to store all the top coordinates of the histograms
         tops = []

--- a/lib/matplotlib/tests/test_hist_density_range.py
+++ b/lib/matplotlib/tests/test_hist_density_range.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+
+from matplotlib import pyplot as plt
+
+
+def _assert_bin_range(bins, expected_range=(0, 1)):
+    assert bins[0] == pytest.approx(expected_range[0])
+    assert bins[-1] == pytest.approx(expected_range[1])
+
+
+@pytest.mark.parametrize("density", [False, True])
+def test_hist_preserves_range_auto_single_dataset(density):
+    fig, ax = plt.subplots()
+    try:
+        data = np.array([0.05, 0.15, 0.35, 0.65, 0.85])
+        _, bins, _ = ax.hist(
+            data,
+            bins="auto",
+            range=(0, 1),
+            density=density,
+        )
+    finally:
+        plt.close(fig)
+
+    _assert_bin_range(bins)
+
+
+@pytest.mark.parametrize("density", [False, True])
+def test_hist_preserves_range_int_bins_single_dataset(density):
+    fig, ax = plt.subplots()
+    try:
+        data = np.array([0.05, 0.25, 0.45, 0.65, 0.85])
+        _, bins, _ = ax.hist(
+            data,
+            bins=5,
+            range=(0, 1),
+            density=density,
+        )
+    finally:
+        plt.close(fig)
+
+    _assert_bin_range(bins)
+
+
+@pytest.mark.parametrize("density", [False, True])
+def test_hist_preserves_range_multiple_datasets(density):
+    fig, ax = plt.subplots()
+    try:
+        datasets = (
+            np.array([0.05, 0.15, 0.25, 0.35]),
+            np.array([0.55, 0.65, 0.75, 0.85]),
+        )
+        _, bins, _ = ax.hist(
+            datasets,
+            bins="auto",
+            range=(0, 1),
+            density=density,
+        )
+    finally:
+        plt.close(fig)
+
+    _assert_bin_range(bins)
+
+
+def test_hist_preserves_range_with_weights_density_true():
+    fig, ax = plt.subplots()
+    try:
+        data = np.array([0.1, 0.3, 0.6, 0.9])
+        weights = np.array([1.0, 0.5, 2.0, 1.5])
+        _, bins, _ = ax.hist(
+            data,
+            # numpy disallows automatic bin selection when weights are used.
+            bins=5,
+            range=(0, 1),
+            weights=weights,
+            density=True,
+        )
+    finally:
+        plt.close(fig)
+
+    _assert_bin_range(bins)


### PR DESCRIPTION
## Summary
- fix Axes.hist so density normalization preserves existing histogram kwargs, including user-provided ranges (#5)
- add regression tests covering range preservation for auto/int bins, multiple datasets, and weighted inputs

## Testing
- MPLBACKEND=Agg LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib python -m pytest lib/matplotlib/tests/test_hist_density_range.py
- MPLBACKEND=Agg LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib python -m pytest lib/matplotlib/tests/test_axes.py -k "hist_auto_bins"
- flake8 lib/matplotlib/axes/_axes.py lib/matplotlib/tests/test_hist_density_range.py

## Reproduction steps
```python
import numpy as np
import matplotlib.pyplot as plt
_, bins, _ = plt.hist(np.random.rand(10), "auto", range=(0, 1), density=True)
print(bins)
```

### Observed failure
Bins do not start at 0 or end at 1 (e.g. `[0.0033..., 0.9332...]`) when `density=True`.

### Stack trace
No stack trace is produced; this is a logical behavior bug.

Fixes #5.