### PR TITLE
swev-id: matplotlib__matplotlib-14623 - Fix log-scale inversion with reversed limits

### DIFF
--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -148,6 +148,12 @@ def test_logscale_reversed_limits_invert():
     assert ax.xaxis_inverted()
     assert_allclose(ax.get_xlim(), (x.max(), x.min()))
 
+    fig, ax = plt.subplots()
+    ax.set_yscale('log')
+    locator = ax.yaxis.get_major_locator()
+    ax.dataLim._minpos[1] = 100
+    assert_allclose(locator.nonsingular(10, -1), (100, 10))
+
 
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,
                   extensions=['png'], tol=0.02, style='mpl20')

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -133,6 +133,22 @@ def test_logscale_transform_repr():
     s = repr(Log10Transform(nonpos='clip'))
 
 
+def test_logscale_reversed_limits_invert():
+    y = np.geomspace(1, 1e5, 100)
+    fig, ax = plt.subplots()
+    ax.set_yscale('log')
+    ax.set_ylim(y.max(), y.min())
+    assert ax.yaxis_inverted()
+    assert_allclose(ax.get_ylim(), (y.max(), y.min()))
+
+    x = np.geomspace(1, 1e5, 100)
+    fig, ax = plt.subplots()
+    ax.set_xscale('log')
+    ax.set_xlim(x.max(), x.min())
+    assert ax.xaxis_inverted()
+    assert_allclose(ax.get_xlim(), (x.max(), x.min()))
+
+
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,
                   extensions=['png'], tol=0.02, style='mpl20')
 def test_logscale_nonpos_values():

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2396,7 +2396,10 @@ class LogLocator(Locator):
         if vmin == vmax:
             vmin = _decade_less(vmin, self._base)
             vmax = _decade_greater(vmax, self._base)
-        return (vmax, vmin) if descending else (vmin, vmax)
+        if vmin > vmax:
+            vmin, vmax = vmax, vmin
+        lo, hi = vmin, vmax
+        return (hi, lo) if descending else (lo, hi)
 
 
 class SymmetricalLogLocator(Locator):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2376,16 +2376,17 @@ class LogLocator(Locator):
         return vmin, vmax
 
     def nonsingular(self, vmin, vmax):
+        descending = vmin > vmax
         if not np.isfinite(vmin) or not np.isfinite(vmax):
-            return 1, 10  # initial range, no data plotted yet
+            return (10, 1) if descending else (1, 10)
 
-        if vmin > vmax:
+        if descending:
             vmin, vmax = vmax, vmin
         if vmax <= 0:
             cbook._warn_external(
                 "Data has no positive values, and therefore cannot be "
                 "log-scaled.")
-            return 1, 10
+            return (10, 1) if descending else (1, 10)
 
         minpos = self.axis.get_minpos()
         if not np.isfinite(minpos):
@@ -2395,7 +2396,7 @@ class LogLocator(Locator):
         if vmin == vmax:
             vmin = _decade_less(vmin, self._base)
             vmax = _decade_greater(vmax, self._base)
-        return vmin, vmax
+        return (vmax, vmin) if descending else (vmin, vmax)
 
 
 class SymmetricalLogLocator(Locator):


### PR DESCRIPTION
## Summary
- preserve the caller-provided orientation inside `LogLocator.nonsingular`
- add a regression test covering reversed limits for log-scaled axes

Fixes #6.

## Reproduction
```python
import matplotlib
matplotlib.use('Agg')
import matplotlib.pyplot as plt
import numpy as np

y = np.geomspace(1, 1e5, 100)
fig, ax = plt.subplots()
ax.set_yscale('log')
ax.set_ylim(y.max(), y.min())
print(ax.get_ylim())
print(ax.yaxis_inverted())
```

Before this change:
- `ax.get_ylim()` -> `(1.0, 100000.0)`
- `ax.yaxis_inverted()` -> `False`

With this patch the limits remain `(100000.0, 1.0)` and the axis reports `True`.

## Testing
- `pytest lib/matplotlib/tests/test_scale.py::test_logscale_reversed_limits_invert -q`