### PR TITLE
fix: guard LogNorm vmin for resampling (swev-id: matplotlib__matplotlib-20488)

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -533,8 +533,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 # that may have moved input values in/out of range
                 s_vmin, s_vmax = vrange
                 if isinstance(self.norm, mcolors.LogNorm):
-                    if s_vmin < 0:
-                        s_vmin = max(s_vmin, np.finfo(scaled_dtype).eps)
+                    if s_vmin <= 0:
+                        s_vmin = np.finfo(scaled_dtype).tiny
                 with cbook._setattr_cm(self.norm,
                                        vmin=s_vmin,
                                        vmax=s_vmax,


### PR DESCRIPTION
## Observed failure
- `lib/matplotlib/tests/test_image.py::test_huge_range_log` raises `ValueError: Invalid vmin or vmax` under NumPy 1.21.x because the resampling path feeds `LogNorm` a non-positive `vmin`.

## Stack trace excerpt
```
>           raise ValueError("Invalid vmin or vmax")
E           ValueError: Invalid vmin or vmax
lib/matplotlib/colors.py:1477: ValueError
```

## Reproduction steps
1. Create a venv, install Matplotlib in editable mode, and install test deps.
2. `pip install 'numpy==1.21.*' pillow pytest`
3. `MPLBACKEND=Agg pytest lib/matplotlib/tests/test_image.py::test_huge_range_log -q`
   - Fails with the ValueError above on 1.21.x
4. `pip install 'numpy==1.20.*' --force-reinstall`
5. Re-run the test to confirm the failure is specific to 1.21.x.
6. Apply this patch and rerun the test under NumPy 1.21.x to confirm it now passes.

## Fix
- Clamp `AxesImage._make_image`'s LogNorm `s_vmin` to `np.finfo(scaled_dtype).tiny` whenever interpolation yields a non-positive value, ensuring the log transform stays finite.

## Testing
- `MPLBACKEND=Agg pytest lib/matplotlib/tests/test_image.py::test_huge_range_log -q` (NumPy 1.21.6)

Fixes #8