### PR TITLE
swev-id: matplotlib__matplotlib-20826 - restore cla tick defaults

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -650,36 +650,7 @@ class _AxesBase(martist.Artist):
                 axis.callbacks.connect(
                     'units', self._unit_change_handler(name)))
 
-        rcParams = mpl.rcParams
-        self.tick_params(
-            top=rcParams['xtick.top'] and rcParams['xtick.minor.top'],
-            bottom=rcParams['xtick.bottom'] and rcParams['xtick.minor.bottom'],
-            labeltop=(rcParams['xtick.labeltop'] and
-                      rcParams['xtick.minor.top']),
-            labelbottom=(rcParams['xtick.labelbottom'] and
-                         rcParams['xtick.minor.bottom']),
-            left=rcParams['ytick.left'] and rcParams['ytick.minor.left'],
-            right=rcParams['ytick.right'] and rcParams['ytick.minor.right'],
-            labelleft=(rcParams['ytick.labelleft'] and
-                       rcParams['ytick.minor.left']),
-            labelright=(rcParams['ytick.labelright'] and
-                        rcParams['ytick.minor.right']),
-            which='minor')
-
-        self.tick_params(
-            top=rcParams['xtick.top'] and rcParams['xtick.major.top'],
-            bottom=rcParams['xtick.bottom'] and rcParams['xtick.major.bottom'],
-            labeltop=(rcParams['xtick.labeltop'] and
-                      rcParams['xtick.major.top']),
-            labelbottom=(rcParams['xtick.labelbottom'] and
-                         rcParams['xtick.major.bottom']),
-            left=rcParams['ytick.left'] and rcParams['ytick.major.left'],
-            right=rcParams['ytick.right'] and rcParams['ytick.major.right'],
-            labelleft=(rcParams['ytick.labelleft'] and
-                       rcParams['ytick.major.left']),
-            labelright=(rcParams['ytick.labelright'] and
-                        rcParams['ytick.major.right']),
-            which='major')
+        self._apply_rcparams_tick_visibility()
 
     def __getstate__(self):
         # The renderer should be re-created by the figure, and then cached at
@@ -1179,6 +1150,38 @@ class _AxesBase(martist.Artist):
         self.set_ylim(y0, y1, emit=False, auto=other.get_autoscaley_on())
         self.yaxis._scale = other.yaxis._scale
 
+    def _apply_rcparams_tick_visibility(self):
+        rcParams = mpl.rcParams
+        self.tick_params(
+            top=rcParams['xtick.top'] and rcParams['xtick.minor.top'],
+            bottom=rcParams['xtick.bottom'] and rcParams['xtick.minor.bottom'],
+            labeltop=(rcParams['xtick.labeltop'] and
+                      rcParams['xtick.minor.top']),
+            labelbottom=(rcParams['xtick.labelbottom'] and
+                         rcParams['xtick.minor.bottom']),
+            left=rcParams['ytick.left'] and rcParams['ytick.minor.left'],
+            right=rcParams['ytick.right'] and rcParams['ytick.minor.right'],
+            labelleft=(rcParams['ytick.labelleft'] and
+                       rcParams['ytick.minor.left']),
+            labelright=(rcParams['ytick.labelright'] and
+                        rcParams['ytick.minor.right']),
+            which='minor')
+
+        self.tick_params(
+            top=rcParams['xtick.top'] and rcParams['xtick.major.top'],
+            bottom=rcParams['xtick.bottom'] and rcParams['xtick.major.bottom'],
+            labeltop=(rcParams['xtick.labeltop'] and
+                      rcParams['xtick.major.top']),
+            labelbottom=(rcParams['xtick.labelbottom'] and
+                         rcParams['xtick.major.bottom']),
+            left=rcParams['ytick.left'] and rcParams['ytick.major.left'],
+            right=rcParams['ytick.right'] and rcParams['ytick.major.right'],
+            labelleft=(rcParams['ytick.labelleft'] and
+                       rcParams['ytick.major.left']),
+            labelright=(rcParams['ytick.labelright'] and
+                        rcParams['ytick.major.right']),
+            which='major')
+
     def cla(self):
         """Clear the axes."""
         # Note: this is called by Axes.__init__()
@@ -1309,36 +1312,7 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_visible(yaxis_visible)
             self.patch.set_visible(patch_visible)
 
-        rcParams = mpl.rcParams
-        self.tick_params(
-            top=rcParams['xtick.top'] and rcParams['xtick.minor.top'],
-            bottom=rcParams['xtick.bottom'] and rcParams['xtick.minor.bottom'],
-            labeltop=(rcParams['xtick.labeltop'] and
-                      rcParams['xtick.minor.top']),
-            labelbottom=(rcParams['xtick.labelbottom'] and
-                         rcParams['xtick.minor.bottom']),
-            left=rcParams['ytick.left'] and rcParams['ytick.minor.left'],
-            right=rcParams['ytick.right'] and rcParams['ytick.minor.right'],
-            labelleft=(rcParams['ytick.labelleft'] and
-                       rcParams['ytick.minor.left']),
-            labelright=(rcParams['ytick.labelright'] and
-                        rcParams['ytick.minor.right']),
-            which='minor')
-
-        self.tick_params(
-            top=rcParams['xtick.top'] and rcParams['xtick.major.top'],
-            bottom=rcParams['xtick.bottom'] and rcParams['xtick.major.bottom'],
-            labeltop=(rcParams['xtick.labeltop'] and
-                      rcParams['xtick.major.top']),
-            labelbottom=(rcParams['xtick.labelbottom'] and
-                         rcParams['xtick.major.bottom']),
-            left=rcParams['ytick.left'] and rcParams['ytick.major.left'],
-            right=rcParams['ytick.right'] and rcParams['ytick.major.right'],
-            labelleft=(rcParams['ytick.labelleft'] and
-                       rcParams['ytick.major.left']),
-            labelright=(rcParams['ytick.labelright'] and
-                        rcParams['ytick.major.right']),
-            which='major')
+        self._apply_rcparams_tick_visibility()
 
         label_outer_xaxis = getattr(self, "_label_outer_xaxis", None)
         if label_outer_xaxis is not None and hasattr(self, "_subplotspec"):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1309,6 +1309,44 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_visible(yaxis_visible)
             self.patch.set_visible(patch_visible)
 
+        rcParams = mpl.rcParams
+        self.tick_params(
+            top=rcParams['xtick.top'] and rcParams['xtick.minor.top'],
+            bottom=rcParams['xtick.bottom'] and rcParams['xtick.minor.bottom'],
+            labeltop=(rcParams['xtick.labeltop'] and
+                      rcParams['xtick.minor.top']),
+            labelbottom=(rcParams['xtick.labelbottom'] and
+                         rcParams['xtick.minor.bottom']),
+            left=rcParams['ytick.left'] and rcParams['ytick.minor.left'],
+            right=rcParams['ytick.right'] and rcParams['ytick.minor.right'],
+            labelleft=(rcParams['ytick.labelleft'] and
+                       rcParams['ytick.minor.left']),
+            labelright=(rcParams['ytick.labelright'] and
+                        rcParams['ytick.minor.right']),
+            which='minor')
+
+        self.tick_params(
+            top=rcParams['xtick.top'] and rcParams['xtick.major.top'],
+            bottom=rcParams['xtick.bottom'] and rcParams['xtick.major.bottom'],
+            labeltop=(rcParams['xtick.labeltop'] and
+                      rcParams['xtick.major.top']),
+            labelbottom=(rcParams['xtick.labelbottom'] and
+                         rcParams['xtick.major.bottom']),
+            left=rcParams['ytick.left'] and rcParams['ytick.major.left'],
+            right=rcParams['ytick.right'] and rcParams['ytick.major.right'],
+            labelleft=(rcParams['ytick.labelleft'] and
+                       rcParams['ytick.major.left']),
+            labelright=(rcParams['ytick.labelright'] and
+                        rcParams['ytick.major.right']),
+            which='major')
+
+        label_outer_xaxis = getattr(self, "_label_outer_xaxis", None)
+        if label_outer_xaxis is not None and hasattr(self, "_subplotspec"):
+            label_outer_xaxis()
+        label_outer_yaxis = getattr(self, "_label_outer_yaxis", None)
+        if label_outer_yaxis is not None and hasattr(self, "_subplotspec"):
+            label_outer_yaxis()
+
         self.stale = True
 
     class ArtistList(MutableSequence):

--- a/lib/matplotlib/tests/test_axes_clear_shared_ticks.py
+++ b/lib/matplotlib/tests/test_axes_clear_shared_ticks.py
@@ -1,0 +1,76 @@
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+
+def test_clear_respects_tick_side_defaults():
+    with mpl.rc_context({
+        "xtick.top": False,
+        "ytick.right": False,
+        "xtick.minor.top": False,
+        "ytick.minor.right": False,
+        "xtick.minor.visible": True,
+        "ytick.minor.visible": True,
+    }):
+        fig, ax = plt.subplots()
+        try:
+            ax.plot([0, 1], [0, 1])
+            ax.clear()
+            ax.plot([0, 1], [0, 1])
+            ax.minorticks_on()
+            fig.canvas.draw()
+
+            assert all(
+                not tick.tick2line.get_visible()
+                for tick in ax.xaxis.get_major_ticks()
+            )
+            assert all(
+                not tick.tick2line.get_visible()
+                for tick in ax.yaxis.get_major_ticks()
+            )
+            x_minor = ax.xaxis.get_minor_ticks()
+            if x_minor:
+                assert all(
+                    not tick.tick2line.get_visible()
+                    for tick in x_minor
+                )
+            y_minor = ax.yaxis.get_minor_ticks()
+            if y_minor:
+                assert all(
+                    not tick.tick2line.get_visible()
+                    for tick in y_minor
+                )
+        finally:
+            plt.close(fig)
+
+
+def test_clear_shared_axes_hide_interior_labels():
+    fig, axes = plt.subplots(2, 2, sharex=True, sharey=True)
+    try:
+        for ax in axes.flat:
+            ax.clear()
+            ax.plot([0, 1], [0, 1])
+
+        fig.canvas.draw()
+
+        nrows, ncols = axes.shape
+        for idx, ax in enumerate(axes.flat):
+            row, col = divmod(idx, ncols)
+            x_label_vis = [tick.label1.get_visible()
+                           for tick in ax.xaxis.get_major_ticks()]
+            y_label_vis = [tick.label1.get_visible()
+                           for tick in ax.yaxis.get_major_ticks()]
+
+            assert x_label_vis
+            assert y_label_vis
+
+            if row < nrows - 1:
+                assert all(not vis for vis in x_label_vis)
+            else:
+                assert any(x_label_vis)
+
+            if col > 0:
+                assert all(not vis for vis in y_label_vis)
+            else:
+                assert any(y_label_vis)
+    finally:
+        plt.close(fig)

--- a/lib/matplotlib/tests/test_axes_clear_shared_ticks.py
+++ b/lib/matplotlib/tests/test_axes_clear_shared_ticks.py
@@ -28,17 +28,17 @@ def test_clear_respects_tick_side_defaults():
                 for tick in ax.yaxis.get_major_ticks()
             )
             x_minor = ax.xaxis.get_minor_ticks()
-            if x_minor:
-                assert all(
-                    not tick.tick2line.get_visible()
-                    for tick in x_minor
-                )
+            assert x_minor
+            assert all(
+                not tick.tick2line.get_visible()
+                for tick in x_minor
+            )
             y_minor = ax.yaxis.get_minor_ticks()
-            if y_minor:
-                assert all(
-                    not tick.tick2line.get_visible()
-                    for tick in y_minor
-                )
+            assert y_minor
+            assert all(
+                not tick.tick2line.get_visible()
+                for tick in y_minor
+            )
         finally:
             plt.close(fig)
 


### PR DESCRIPTION
## Summary
- reapply the rcParams-driven tick_params blocks in `_AxesBase.cla`
- re-hide shared-axis interior labels via the label_outer helpers when available
- add regression tests covering top/right ticks and shared label visibility after `clear()`

## Reproduction Steps
```python
import numpy as np
import matplotlib.pyplot as plt

fig, axes = plt.subplots(2, 2, sharex=True, sharey=True)

x = np.arange(0.0, 2*np.pi, 0.01)
y = np.sin(x)

for ax in axes.flatten():
    ax.clear()
    ax.plot(x, y)

plt.show()
```

## Observed Failure Before
- `ax.clear()` enabled top/right ticks despite rcParams defaults and left shared subplot interior tick labels visible.

## Observed Behavior After
- Top/right ticks stay hidden per rcParams (no extra ticks appear) and shared subplots keep interior tick labels hidden again. No exception is raised because this was a visual regression.

## Logs / Notes
- Running the reproduction script with `MPLBACKEND=Agg` prints `top tick2 visible? False` and shows interior axes with hidden labels except on the outer edges after the fix.