### PR TITLE
swev-id: matplotlib__matplotlib-20676 fix: preserve SpanSelector limits

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -223,6 +223,28 @@ def test_span_selector():
     check_span('horizontal', rectprops=dict(fill=True))
 
 
+def test_span_selector_no_autoscale_on_init():
+    fig, ax = plt.subplots()
+    ax.plot([10, 20], [10, 20])
+    xlim_before = ax.get_xlim()
+
+    widgets.SpanSelector(
+        ax, lambda vmin, vmax: None, 'horizontal', interactive=True)
+
+    assert ax.get_xlim() == xlim_before
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    ax.plot([10, 20], [10, 20])
+    ylim_before = ax.get_ylim()
+
+    widgets.SpanSelector(
+        ax, lambda vmin, vmax: None, 'vertical', interactive=True)
+
+    assert ax.get_ylim() == ylim_before
+    plt.close(fig)
+
+
 @pytest.mark.parametrize('drag_from_anywhere', [True, False])
 def test_span_selector_drag(drag_from_anywhere):
     ax = get_ax()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2139,12 +2139,16 @@ class SpanSelector(_SelectorWidget):
             self.connect_default_events()
 
         if self.direction == 'horizontal':
+            x0 = ax.get_xlim()[0]
             trans = ax.get_xaxis_transform()
+            xy = (x0, 0)
             w, h = 0, 1
         else:
+            y0 = ax.get_ylim()[0]
             trans = ax.get_yaxis_transform()
+            xy = (0, y0)
             w, h = 1, 0
-        self._rect = Rectangle((0, 0), w, h,
+        self._rect = Rectangle(xy, w, h,
                                transform=trans,
                                visible=False,
                                **self._rectprops)


### PR DESCRIPTION
## Summary
- implement Emerson's guidance for SpanSelector so the initial rectangle lives at the current axis bounds instead of 0
- add a regression test that exercises interactive horizontal and vertical selectors against positive-only data
- verified the original failure with the provided script and confirmed the fix maintains the original limits

## Issue
- closes #12

## Reproduction steps
1. Run the script below with Matplotlib built from `matplotlib__matplotlib-20676` (Agg backend).
2. Observe that `xlim`/`ylim` expand to include 0 immediately after instantiating `SpanSelector(..., interactive=True)`.

```python
from matplotlib import pyplot as plt
from matplotlib.widgets import SpanSelector

fig, ax = plt.subplots()
ax.plot([10, 20], [10, 20])
print('xlim before:', ax.get_xlim())
ss = SpanSelector(ax, lambda *_, **__: None, 'horizontal', interactive=True)
print('xlim after:', ax.get_xlim())
```

## Observed failure
- The axis limits jump from approximately `(9.5, 20.5)` to `(-1.0, 21.0)` for both `xlim` and `ylim`, expanding to include 0.

## Stack trace prior to the fix
```
Traceback (most recent call last):
  File "<stdin>", line 8, in <module>
AssertionError: ((np.float64(-1.0000000000000009), np.float64(21.0)), (np.float64(9.5), np.float64(20.5)))
```

## Root cause
- `SpanSelector.new_axes` seeded the interactive rectangle (and thus its handles) at data coordinate 0 using blended data/axes transforms. Adding that artist triggered autoscale-on-add, forcing the limits to include 0 even when all plotted data was positive.

## Fix
- Initialize the rectangle (and the resulting extents) at the current axis lower bound: use `ax.get_xlim()[0]` for horizontal selectors and `ax.get_ylim()[0]` for vertical selectors, while keeping width or height at 0 and relying on the existing axis transforms.

## Testing
- `MPLBACKEND=Agg pytest lib/matplotlib/tests/test_widgets.py::test_span_selector_no_autoscale_on_init`
- `MPLBACKEND=Agg pytest lib/matplotlib/tests/test_widgets.py -k span_selector`
- `flake8 lib/matplotlib/widgets.py lib/matplotlib/tests/test_widgets.py`