### PR TITLE
[skip ci] Fix: Make datetime tick labels clear under usetex by protecting space/colon/hyphen

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -595,8 +595,16 @@ def _wrap_in_tex(text):
     p = r'([a-zA-Z]+)'
     ret_text = re.sub(p, r'}$\1$\\mathdefault{', text)
 
-    # Braces ensure dashes are not spaced like binary operators.
-    ret_text = '$\\mathdefault{'+ret_text.replace('-', '{-}')+'}$'
+    # Braces ensure dashes/colons are not spaced like operators in math mode.
+    # Replace spaces with a math space so TeX does not collapse them.
+    ret_text = (
+        '$\\mathdefault{' +
+        ret_text
+        .replace('-', '{-}')
+        .replace(':', '{:}')
+        .replace(' ', r'\;') +
+        '}$'
+    )
     ret_text = ret_text.replace('$\\mathdefault{}$', '')
     return ret_text
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -325,9 +325,9 @@ def test_date_formatter_callable():
     (datetime.timedelta(weeks=52 * 200),
      [r'$\mathdefault{%d}$' % (year,) for year in range(1990, 2171, 20)]),
     (datetime.timedelta(days=30),
-     [r'Jan$\mathdefault{ %02d 1990}$' % (day,) for day in range(1, 32, 3)]),
+     [r'Jan$\mathdefault{\;%02d\;1990}$' % (day,) for day in range(1, 32, 3)]),
     (datetime.timedelta(hours=20),
-     [r'$\mathdefault{%02d:00:00}$' % (hour,) for hour in range(0, 21, 2)]),
+     [r'$\mathdefault{%02d{:}00{:}00}$' % (hour,) for hour in range(0, 21, 2)]),
 ])
 def test_date_formatter_usetex(delta, expected):
     d1 = datetime.datetime(1990, 1, 1)
@@ -609,14 +609,14 @@ def test_concise_formatter_show_offset(t_delta, expected):
       '$\\mathdefault{25}$', '$\\mathdefault{29}$', 'Feb',
       '$\\mathdefault{05}$', '$\\mathdefault{09}$']),
     (datetime.timedelta(hours=40),
-     ['Jan$\\mathdefault{{-}01}$', '$\\mathdefault{04:00}$',
-      '$\\mathdefault{08:00}$', '$\\mathdefault{12:00}$',
-      '$\\mathdefault{16:00}$', '$\\mathdefault{20:00}$',
-      'Jan$\\mathdefault{{-}02}$', '$\\mathdefault{04:00}$',
-      '$\\mathdefault{08:00}$', '$\\mathdefault{12:00}$',
-      '$\\mathdefault{16:00}$']),
+     ['Jan$\\mathdefault{{-}01}$', '$\\mathdefault{04{:}00}$',
+      '$\\mathdefault{08{:}00}$', '$\\mathdefault{12{:}00}$',
+      '$\\mathdefault{16{:}00}$', '$\\mathdefault{20{:}00}$',
+      'Jan$\\mathdefault{{-}02}$', '$\\mathdefault{04{:}00}$',
+      '$\\mathdefault{08{:}00}$', '$\\mathdefault{12{:}00}$',
+      '$\\mathdefault{16{:}00}$']),
     (datetime.timedelta(seconds=2),
-     ['$\\mathdefault{59.5}$', '$\\mathdefault{00:00}$',
+     ['$\\mathdefault{59.5}$', '$\\mathdefault{00{:}00}$',
       '$\\mathdefault{00.5}$', '$\\mathdefault{01.0}$',
       '$\\mathdefault{01.5}$', '$\\mathdefault{02.0}$',
       '$\\mathdefault{02.5}$']),
@@ -1200,3 +1200,12 @@ def test_julian2num():
     mdates.set_epoch('1970-01-01T00:00:00')
     assert mdates.julian2num(2440588.5) == 1.0
     assert mdates.num2julian(2.0) == 2440589.5
+
+
+def test_wrap_in_tex_protects_characters():
+    # Directly test the TeX wrapper used by date formatters when usetex=True.
+    from matplotlib.dates import _wrap_in_tex
+    assert _wrap_in_tex('12:34') == '$\\mathdefault{12{:}34}$'
+    assert _wrap_in_tex('2021-01-02') == '$\\mathdefault{2021{-}01{-}02}$'
+    assert _wrap_in_tex('Jan 02 1990') == 'Jan$\\mathdefault{\\;02\\;1990}$'
+    assert _wrap_in_tex('00:00:59') == '$\\mathdefault{00{:}00{:}59}$'


### PR DESCRIPTION
Fixes unclear TeX spacing for datetime tick labels when rcParams['text.usetex']=True in 3.4.x.\n\nProblem\n- In 3.4.x, DateFormatter/ConciseDateFormatter wrap labels in $\mathdefault{...}$, but TeX math mode collapses spaces and adds math spacing around ':' and '-' leading to unclear labels. 3.3.x did not have this issue.\n\nMinimal fix\n- Update matplotlib/dates.py:_wrap_in_tex to additionally: \n  - Replace spaces ' ' with \\; (math space) so TeX does not collapse them.\n  - Replace ':' with '{:}' to avoid relation-operator spacing.\n  - Keep existing '{-}' protection for hyphen-minus.\n  - Continue wrapping full string in $\mathdefault{...}$ and the existing alpha-run handling.\n\nRationale\n- Using \\; matches visual word spacing better across engines and maintains non-breaking behavior.\n- Bracing ':' and '-' prevents TeX from applying math operator spacing, matching 3.3 visuals.\n- Minimal change localized to _wrap_in_tex only.\n\nEdge cases\n- Locales with different separators are unaffected (we only touch space, ':' and '-').\n- Unicode minus (U+2212) remains untouched (we only brace ASCII '-').\n- Long labels/timezone abbreviations are safe; letters are already handled by the existing alpha-run switching in _wrap_in_tex.\n\nTests\n- Updated usetex expectations in tests that assert formatter outputs.\n- Added unit test test_wrap_in_tex_protects_characters covering spaces (to \\;), hyphen (to {-}), colon (to {:}), and mathdefault wrapping.\n\nRepro snippet\n\nObserved (3.4.x): Collapsed spaces; extra spacing around ':' and '-'.\nExpected: Natural spacing like 3.3.x.\n\nCompatibility\n- Works with usetex LaTeX engines (pdftex/xelatex/lualatex) and Matplotlib mathtext.\n- Change is limited to TeX-wrapped content; non-usetex label rendering unchanged.\n