### PR TITLE
swev-id: matplotlib__matplotlib-20859 - Support SubFigure legends

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1582,8 +1582,14 @@ default: %(va)s
         return projection_class, kwargs
 
     def get_default_bbox_extra_artists(self):
-        bbox_artists = [artist for artist in self.get_children()
-                        if (artist.get_visible() and artist.get_in_layout())]
+        bbox_artists = []
+        for artist in self.get_children():
+            if not (artist.get_visible() and artist.get_in_layout()):
+                continue
+            if isinstance(artist, SubFigure):
+                bbox_artists.extend(artist.get_default_bbox_extra_artists())
+            else:
+                bbox_artists.append(artist)
         for ax in self.axes:
             if ax.get_visible():
                 bbox_artists.extend(ax.get_default_bbox_extra_artists())

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -360,7 +360,7 @@ class Legend(Artist):
         """
         # local import only to avoid circularity
         from matplotlib.axes import Axes
-        from matplotlib.figure import Figure
+        from matplotlib.figure import FigureBase
 
         super().__init__()
 
@@ -434,11 +434,11 @@ class Legend(Artist):
             self.isaxes = True
             self.axes = parent
             self.set_figure(parent.figure)
-        elif isinstance(parent, Figure):
+        elif isinstance(parent, FigureBase):
             self.isaxes = False
             self.set_figure(parent)
         else:
-            raise TypeError("Legend needs either Axes or Figure as parent")
+            raise TypeError("Legend needs either Axes or FigureBase as parent")
         self.parent = parent
 
         self._loc_used_default = loc is None

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -506,7 +506,7 @@ def test_warn_cl_plus_tl():
     with pytest.warns(UserWarning):
         # this should warn,
         fig.subplots_adjust(top=0.8)
-    assert not(fig.get_constrained_layout())
+    assert not fig.get_constrained_layout()
 
 
 @check_figures_equal(extensions=["png", "pdf"])
@@ -571,6 +571,27 @@ def test_tightbbox():
     # test bbox_extra_artists method...
     assert abs(ax.get_tightbbox(renderer, bbox_extra_artists=[]).x1
                - x1Nom * fig.dpi) < 2
+
+
+def test_bboxtight_includes_subfigure_legend():
+    fig = plt.figure()
+    subfig = fig.subfigures(1, 1)
+    ax = subfig.add_subplot()
+    ax.plot([0, 1], [0, 1], label='line')
+
+    legend = subfig.legend(loc='upper right')
+
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+
+    legend_bbox = legend.get_tightbbox(renderer)
+    fig_bbox = fig.get_tightbbox(renderer)
+    fig_bbox_display = fig_bbox.transformed(fig.dpi_scale_trans)
+
+    tol = 1e-3
+    for x, y in legend_bbox.corners():
+        assert fig_bbox_display.x0 - tol <= x <= fig_bbox_display.x1 + tol
+        assert fig_bbox_display.y0 - tol <= y <= fig_bbox_display.y1 + tol
 
 
 def test_axes_removal():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -35,6 +35,18 @@ def test_legend_ordereddict():
               loc='center left', bbox_to_anchor=(1, .5))
 
 
+def test_subfigure_legend_creation():
+    fig = plt.figure()
+    subfig = fig.subfigures(1, 1)
+    ax = subfig.add_subplot()
+    ax.plot([0, 1], [0, 1], label='line')
+
+    legend = subfig.legend()
+
+    assert isinstance(legend, mlegend.Legend)
+    assert len(subfig.legends) == 1
+
+
 @image_comparison(['legend_auto1'], remove_text=True)
 def test_legend_auto1():
     """Test automatic legend placement"""


### PR DESCRIPTION
## Summary
- allow Legends to accept FigureBase parents so SubFigure.legend works
- flatten SubFigure entries in FigureBase.get_default_bbox_extra_artists to include SubFigure legends in tight bbox unions
- add regression tests covering SubFigure legends and bbox_inches='tight'

## Observed failure
Attempting to call SubFigure.legend() raised a TypeError because Legend.__init__ only accepted Figure parents:
```python-traceback
Traceback (most recent call last):
  File "bug_test.py", line 5, in <module>
    subfig.legend()
  File "/.../matplotlib/lib/matplotlib/figure.py", line 1068, in legend
    l = mlegend.Legend(self, handles, labels, *extra_args,
  File "/.../matplotlib/lib/matplotlib/legend.py", line 441, in __init__
    raise TypeError("Legend needs either Axes or Figure as parent")
TypeError: Legend needs either Axes or Figure as parent
```
This patch changes the parent acceptance to FigureBase and ensures SubFigure legends are included in tight bbox calculations.

## Reproduction steps
```python
import matplotlib.pyplot as plt

subfig = plt.figure().subfigures()
ax = subfig.subplots()
ax.plot([0, 1, 2], [0, 1, 2], label="test")
subfig.legend()
```

## Testing
- MPLBACKEND=Agg pytest lib/matplotlib/tests/test_legend.py::test_subfigure_legend_creation lib/matplotlib/tests/test_figure.py::test_bboxtight_includes_subfigure_legend
- flake8 lib/matplotlib/legend.py lib/matplotlib/tests/test_legend.py lib/matplotlib/tests/test_figure.py
