### PR TITLE
Guard category converter and UnitData info on empty inputs — swev-id: matplotlib__matplotlib-22719

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -58,7 +58,7 @@ class StrCategoryConverter(units.ConversionInterface):
             is_numlike = all(units.ConversionInterface.is_numlike(v)
                              and not isinstance(v, (str, bytes))
                              for v in values)
-        if is_numlike:
+        if values.size and is_numlike:
             _api.warn_deprecated(
                 "3.5", message="Support for passing numbers through unit "
                 "converters is deprecated since %(since)s and support will be "
@@ -230,7 +230,7 @@ class UnitData:
                 convertible = self._str_is_convertible(val)
             if val not in self._mapping:
                 self._mapping[val] = next(self._counter)
-        if convertible:
+        if data.size and convertible:
             _log.info('Using categorical units to plot a list of strings '
                       'that are all parsable as floats or dates. If these '
                       'strings should be plotted as numbers, cast to the '


### PR DESCRIPTION
## Summary
- guard the categorical converter path so empty sequences no longer trigger the deprecated numeric pass-through warning
- guard the UnitData info log so it does not fire for empty updates

## Issue
Fixes #20.

## Reproduction
1. Create a venv and install numpy, pillow, kiwisolver, pyparsing, cycler, packaging, python-dateutil, contourpy, fonttools, and matplotlib.
2. Ensure Matplotlib can load the compiled extensions (symlinked from the wheel) and export the required runtime libs, then run:

```bash
PYTHONPATH=/workspace/matplotlib/lib \
LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib \
MPLBACKEND=Agg \
python3 - <<'PY'
import warnings
import matplotlib
from matplotlib import pyplot as plt
warnings.simplefilter('error', matplotlib._api.MatplotlibDeprecationWarning)
warnings.filterwarnings('ignore', message=r'(?s).*LoadFlags.*', category=matplotlib._api.MatplotlibDeprecationWarning)
f, ax = plt.subplots()
ax.xaxis.update_units(["a", "b"])
ax.plot([], [])
PY
```

### Observed failure
```
Traceback (most recent call last):
  File "/workspace/matplotlib-base/lib/matplotlib/axis.py", line 1622, in convert_units
    ret = self.converter.convert(x, self.units, self)
  File "/workspace/matplotlib-base/lib/matplotlib/category.py", line 62, in convert
    _api.warn_deprecated(
  File "/workspace/matplotlib-base/lib/matplotlib/_api/deprecation.py", line 96, in warn_deprecated
    warn_external(warning, category=MatplotlibDeprecationWarning)
  File "/workspace/matplotlib-base/lib/matplotlib/_api/__init__.py", line 361, in warn_external
    warnings.warn(message, category, stacklevel)
matplotlib._api.deprecation.MatplotlibDeprecationWarning: Support for passing numbers through unit converters is deprecated since 3.5 and support will be removed two minor releases later; use Axis.convert_units instead.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 8, in <module>
  File "/workspace/matplotlib-base/lib/matplotlib/axes/_axes.py", line 1640, in plot
    self.add_line(line)
  File "/workspace/matplotlib-base/lib/matplotlib/axes/_base.py", line 2301, in add_line
    self._update_line_limits(line)
  File "/workspace/matplotlib-base/lib/matplotlib/axes/_base.py", line 2324, in _update_line_limits
    path = line.get_path()
  File "/workspace/matplotlib-base/lib/matplotlib/lines.py", line 995, in get_path
    self.recache()
  File "/workspace/matplotlib-base/lib/matplotlib/lines.py", line 647, in recache
    xconv = self.convert_xunits(self._xorig)
  File "/workspace/matplotlib-base/lib/matplotlib/artist.py", line 250, in convert_xunits
    return ax.xaxis.convert_units(x)
  File "/workspace/matplotlib-base/lib/matplotlib/axis.py", line 1624, in convert_units
    raise munits.ConversionError('Failed to convert value(s) to axis '
matplotlib.units.ConversionError: Failed to convert value(s) to axis units: array([], dtype=float64)
```

## Fix
- short-circuit StrCategoryConverter when the sequence is empty so numeric pass-through is not considered
- only emit the informational UnitData log once at least one element is checked and proved convertible

## Verification
- reran the reproduction script above: no MatplotlibDeprecationWarning for empty inputs
- manually invoked `StrCategoryConverter.convert([1, 2], unit, None)` to confirm non-empty numeric inputs still raise the deprecation warning
- called `UnitData().update([])` while capturing logs to confirm the "parsable as floats or dates" info is suppressed for empty data
- attempted `pytest lib/matplotlib/tests/test_category.py` (with Agg backend and PYTHONPATH pointing at this tree); collection aborts on upstream `MatplotlibDeprecationWarning` for `LoadFlags`/`Kerning` constants because the pytest config turns warnings into errors
