### PR TITLE
swev-id: matplotlib__matplotlib-22865 fix colorbar drawedges extends

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -651,8 +651,13 @@ class Colorbar:
             if not self.drawedges:
                 if len(self._y) >= self.n_rasterize:
                     self.solids.set_rasterized(True)
-        self.dividers.set_segments(
-            np.dstack([X, Y])[1:-1] if self.drawedges else [])
+        if self.drawedges:
+            segs = np.dstack([X, Y])
+            start = 0 if self._extend_lower() else 1
+            stop = None if self._extend_upper() else -1
+            self.dividers.set_segments(segs[start:stop])
+        else:
+            self.dividers.set_segments([])
 
     def _add_solids_patches(self, X, Y, C, mappable):
         hatches = mappable.hatches * len(C)  # Have enough hatches.

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -148,6 +148,40 @@ def test_colorbar_extension_inverted_axis(orientation, extend, expected):
         assert len(cbar._extend_patches) == 1
 
 
+@pytest.mark.parametrize("extend", ["min", "max", "both"])
+@pytest.mark.parametrize("orientation", ["vertical", "horizontal"])
+def test_colorbar_drawedges_extends_extremes(extend, orientation):
+    levels = np.array([0.0, 1.0, 2.0, 3.0])
+    base_colors = ["#4c72b0", "#55a868", "#c44e52"]
+    if extend in {"min", "both"}:
+        color_sequence = ["#000000", *base_colors]
+    else:
+        color_sequence = [*base_colors]
+    if extend in {"max", "both"}:
+        color_sequence = [*color_sequence, "#ffffff"]
+    cmap, norm = mcolors.from_levels_and_colors(
+        levels, color_sequence, extend=extend)
+    fig, ax = plt.subplots()
+    try:
+        sm = cm.ScalarMappable(norm=norm, cmap=cmap)
+        sm.set_array([])
+        cbar = fig.colorbar(sm, ax=ax, orientation=orientation,
+                            drawedges=True)
+        segments = cbar.dividers.get_segments()
+    finally:
+        plt.close(fig)
+    axis_index = 1 if orientation == "vertical" else 0
+    positions = np.array([segment[0, axis_index] for segment in segments])
+    expected = len(levels) - 2
+    if extend in {"min", "both"}:
+        expected += 1
+        assert np.isclose(positions.min(), levels[0])
+    if extend in {"max", "both"}:
+        expected += 1
+        assert np.isclose(positions.max(), levels[-1])
+    assert len(segments) == expected
+
+
 @pytest.mark.parametrize('use_gridspec', [True, False])
 @image_comparison(['cbar_with_orientation',
                    'cbar_locationing',


### PR DESCRIPTION
## Summary
- Fixes #22 by restoring the divider boundary segments that were trimmed when extensions were present with `drawedges=True`
- Expand colorbar tests to cover min/max/both extensions for vertical and horizontal bars so drawedges spans the full range

## Testing
- LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib MPLBACKEND=Agg .venv/bin/pytest -k test_colorbar_drawedges_extends_extremes
- LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib .venv/bin/flake8 lib/matplotlib/colorbar.py lib/matplotlib/tests/test_colorbar.py

## Reproduction
```python
import matplotlib as mpl
import numpy as np
import matplotlib.pyplot as plt  
from matplotlib.colors import from_levels_and_colors

my_cmap = mpl.cm.viridis
bounds = np.arange(10)
nb_colors = len(bounds) + 1
colors = my_cmap(np.linspace(100, 255, nb_colors).astype(int))
my_cmap, my_norm = from_levels_and_colors(bounds, colors, extend='both')

plt.figure(figsize=(5, 1))
ax = plt.subplot(111)
cbar = mpl.colorbar.ColorbarBase(ax, cmap=my_cmap, norm=my_norm, orientation='horizontal', drawedges=True)
plt.subplots_adjust(left=0.05, bottom=0.4, right=0.95, top=0.9)
plt.show()
```
Observed: the colorbar is missing divider edges at both extremities when `extend='both'`.
No stack trace; visual regression only.