### PR TITLE
Fix: ConciseDateFormatter year offset for sub-year views without January (swev-id: matplotlib__matplotlib-22871)

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -796,8 +796,12 @@ class ConciseDateFormatter(ticker.Formatter):
         # mostly 0: years,  1: months,  2: days,
         # 3: hours, 4: minutes, 5: seconds, 6: microseconds
         for level in range(5, -1, -1):
-            if len(np.unique(tickdate[:, level])) > 1:
-                if level < 2:
+            unique = np.unique(tickdate[:, level])
+            if len(unique) > 1:
+                if level < 2 and np.any(unique == 1):
+                    # January ticks already carry the year via zero_formats.
+                    # Otherwise keep the offset so the year appears when
+                    # January is absent.
                     show_offset = False
                 break
             elif level == 0:

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -630,9 +630,30 @@ def test_offset_changes():
     ax.set_xlim(d1, d1 + datetime.timedelta(weeks=3))
     fig.draw_without_rendering()
     assert formatter.get_offset() == '1997-Jan'
+    ax.set_xlim(datetime.datetime(1997, 2, 1), datetime.datetime(1997, 9, 1))
+    fig.draw_without_rendering()
+    assert formatter.get_offset() == '1997'
     ax.set_xlim(d1, d1 + datetime.timedelta(weeks=520))
     fig.draw_without_rendering()
     assert formatter.get_offset() == ''
+
+
+def test_concise_formatter_year_offset_without_january():
+    fig, ax = plt.subplots()
+
+    start = datetime.datetime(2021, 2, 1)
+    end = datetime.datetime(2021, 9, 30)
+
+    locator = mdates.AutoDateLocator()
+    formatter = mdates.ConciseDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+
+    ax.plot([start, end], [0, 1])
+    ax.set_xlim(start, end)
+    fig.draw_without_rendering()
+
+    assert formatter.get_offset() == '2021'
 
 
 @pytest.mark.parametrize('t_delta, expected', [


### PR DESCRIPTION
## Summary
- keep the month-level offset enabled when January is absent so the year remains visible
- retain January's existing behavior by only suppressing the offset when January ticks are present
- extend `test_offset_changes` and add a focused year-offset test covering February–September spans

## Reproduction Steps
```python
import matplotlib.pyplot as plt
import matplotlib.dates as mdates
from datetime import datetime, timedelta

initial = datetime(2021, 2, 14, 0, 0, 0)
time_array = [initial + timedelta(days=x) for x in range(1, 200)]
data = [-x**2/20000 for x in range(1, 200)]

fig, ax = plt.subplots()
ax.plot(time_array, data)
locator = mdates.AutoDateLocator()
formatter = mdates.ConciseDateFormatter(locator)
ax.xaxis.set_major_locator(locator)
ax.xaxis.set_major_formatter(formatter)
fig.autofmt_xdate()
fig.canvas.draw()
print(formatter.get_offset())
```

- Before fix (baseline logic): `formatter.get_offset()` returned an empty string, so the year never appeared. No exception or stack trace was raised.
- After fix: `formatter.get_offset()` prints `2021`, restoring the missing year in the offset.

## Tests Added / Updated
- Updated `test_offset_changes` to cover month windows that exclude January
- Added `test_concise_formatter_year_offset_without_january`

## Local Test Results
- `MPLBACKEND=Agg pytest lib/matplotlib/tests/test_dates.py::test_offset_changes -q`
- `MPLBACKEND=Agg pytest lib/matplotlib/tests/test_dates.py::test_concise_formatter_year_offset_without_january -q`
- `MPLBACKEND=Agg pytest lib/matplotlib/tests/test_dates.py -q`

All tests above pass locally.

## Risks / Edge Cases
- Month spans crossing December–January still suppress the offset because January labels include the year
- Year-level and other time resolutions are unaffected; only month-level behavior toggles based on January's presence