### PR TITLE
swev-id: matplotlib__matplotlib-23299 Preserve figures when resolving auto backend

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -674,7 +674,12 @@ class RcParams(MutableMapping, dict):
             val = dict.__getitem__(self, key)
             if val is rcsetup._auto_backend_sentinel:
                 from matplotlib import pyplot as plt
+                if plt._backend_mod is not None:
+                    import matplotlib.backends
+                    return matplotlib.backends.backend
                 plt.switch_backend(rcsetup._auto_backend_sentinel)
+                return dict.__getitem__(self, key)
+            return val
 
         return dict.__getitem__(self, key)
 

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -270,6 +270,33 @@ def test_lazy_auto_backend_selection():
                 timeout=_test_timeout)
 
 
+def _impl_get_backend_preserves_figures():
+    import matplotlib
+    from matplotlib import get_backend, rc_context, rcsetup
+    from matplotlib import pyplot as plt
+
+    plt.close("all")
+    matplotlib.rcParams["backend"] = rcsetup._auto_backend_sentinel
+
+    with rc_context():
+        plt.figure()
+
+    matplotlib.rcParams["backend"] = rcsetup._auto_backend_sentinel
+    assert plt._backend_mod is not None
+
+    gcf = plt._pylab_helpers.Gcf
+    assert tuple(gcf.figs.items())
+    before = (id(gcf), tuple(gcf.figs.items()))
+    get_backend()
+    after = (id(gcf), tuple(gcf.figs.items()))
+    assert before == after
+
+
+def test_get_backend_preserves_figures():
+    _run_helper(_impl_get_backend_preserves_figures,
+                timeout=_test_timeout)
+
+
 def _implqt5agg():
     import matplotlib.backends.backend_qt5agg  # noqa
     import sys


### PR DESCRIPTION
## Summary
- prevent `RcParams.__getitem__("backend")` from clearing existing figures when `rcParams['backend']` is the auto sentinel and pyplot already picked a backend
- capture the active backend from `matplotlib.backends.backend` instead of re-invoking `switch_backend()` in that state
- add a subprocess regression test that reproduces the original `Gcf.figs` clearing and now verifies the figures remain registered

## Reproduction Steps
```python
import matplotlib.pyplot as plt
from matplotlib import get_backend, rc_context

with rc_context():
    plt.figure()

before = f"{id(plt._pylab_helpers.Gcf)} {plt._pylab_helpers.Gcf.figs!r}"
get_backend()
after = f"{id(plt._pylab_helpers.Gcf)} {plt._pylab_helpers.Gcf.figs!r}"

assert before == after, '\n' + before + '\n' + after
```

### Observed Failure (pre-fix)
```
AssertionError:
94453354309744 OrderedDict([(1, <matplotlib.backends.backend_qt.FigureManagerQT object at 0x...>)])
94453354309744 OrderedDict()
```

The fix avoids calling `switch_backend()` once pyplot already resolved a backend, so the active figures stay intact. Fixes #25.

## Testing
- `MPLBACKEND=Agg pytest lib/matplotlib/tests/test_backends_interactive.py -k get_backend_preserves_figures -vv`

## Testing Notes
- Installed build tooling via `nix profile add ... python310 pip gcc freetype pkg-config zlib gnumake`
- Created a virtualenv, installed editable Matplotlib, and pulled in `requirements/testing/all.txt`
- Downgraded `numpy` to 1.26.4 and `pyparsing` to 3.1.1 per project guidance
- Set `LD_LIBRARY_PATH` to include the Nix GCC runtime libraries before running pytest