### PR TITLE
swev-id: matplotlib__matplotlib-23314 | mplot3d: Axes3D should honor set_visible(False)

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -387,6 +387,10 @@ class Axes3D(Axes):
 
     @martist.allow_rasterization
     def draw(self, renderer):
+        if renderer is None:
+            raise RuntimeError("No renderer defined")
+        if not self.get_visible():
+            return
         self._unstale_viewLim()
 
         # draw the background patch

--- a/lib/mpl_toolkits/tests/test_mplot3d_visibility.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d_visibility.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+
+def test_axes3d_respects_set_visible_false():
+    fig = Figure(figsize=(4, 2), dpi=100)
+    canvas = FigureCanvasAgg(fig)
+
+    ax1 = fig.add_subplot(1, 2, 1, projection='3d')
+    ax2 = fig.add_subplot(1, 2, 2, projection='3d')
+
+    ax1.scatter([1], [1], [1])
+    ax2.scatter([1], [1], [1], c='r')
+
+    # Hide left axes entirely.
+    ax1.set_visible(False)
+
+    # Draw and examine pixels.
+    canvas.draw()
+    im = np.asarray(canvas.buffer_rgba())
+
+    # Use a margin to avoid antialiasing artifacts at figure edges.
+    h, w, _ = im.shape
+    margin = 5
+    left_half = im[margin:-margin, margin:w // 2 - margin, :3]
+
+    # Background is typically uniform; sample a corner pixel.
+    bg = im[margin, margin, :3]
+
+    # Assert that the left half contains only background pixels.
+    assert np.all(left_half == bg)


### PR DESCRIPTION
Task 264 — matplotlib__matplotlib-23314

Summary
- Fixes an mplot3d bug where Axes3D still draws panes/axes even when the Axes is set invisible via `ax.set_visible(False)`.
- Change: Add an early return at the top of `Axes3D.draw()` when `not self.get_visible()`, mirroring 2D Axes behavior.
- Adds a focused Agg-based test to validate invisibility.

Linked issue
- Closes #29

Reproduction (from report)
```python
import matplotlib.pyplot as plt

fig, (ax1, ax2) = plt.subplots(1, 2, subplot_kw={'projection': '3d'})
ax1.scatter(1,1,1)
ax2.scatter(1,1,1, c='r')
ax1.set_visible(False)

plt.show()
```

Observed failure
- Left 3D axes remained visible (background pane and axes/ticks drawn) despite `ax1.set_visible(False)`.

Expected
- Left axes is invisible (no panes/axes/ticks/children drawn), matching 2D Axes semantics.

Root cause (research)
- `Axes3D.draw()` (lib/mpl_toolkits/mplot3d/axes3d.py) drew the background patch and axis panes before calling `super().draw(renderer)` and did not check `Axes.visible` first. In contrast, 2D `Axes.draw()` returns early when invisible.

Fix details
- In `Axes3D.draw(self, renderer)`, add:
  ```python
  if renderer is None:
      raise RuntimeError("No renderer defined")
  if not self.get_visible():
      return
  ```
  before any drawing calls, then proceed as before. This prevents drawing the patch and axes when invisible and aligns 3D with 2D behavior.

Test added
- `lib/mpl_toolkits/tests/test_mplot3d_visibility.py`
  - Renders two 3D subplots, hides the left via `set_visible(False)`, draws with Agg, and asserts the left half contains only background pixels.

Notes
- CI: Not manually triggered per task rules.
- Stack trace: None (visual rendering bug).
- Local test approach: Agg-based pixel inspection (no interactive backends).