### PR TITLE
[Bugfix] Preserve original DPI in pickled figures to avoid HiDPI doubling (swev-id: matplotlib__matplotlib-23476)

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3043,6 +3043,12 @@ class Figure(FigureBase):
 
         self.__dict__ = state
 
+        # Preserve the original DPI that may differ from the figure DPI on
+        # HiDPI backends.  FigureCanvasBase will overwrite ``_original_dpi``
+        # when it reattaches the canvas, so capture it first and restore it
+        # afterwards.
+        original_dpi = getattr(self, "_original_dpi", self.dpi)
+
         # re-initialise some of the unstored state information
         FigureCanvasBase(self)  # Set self.canvas.
 
@@ -3055,6 +3061,8 @@ class Figure(FigureBase):
             mgr = plt._backend_mod.new_figure_manager_given_figure(num, self)
             pylab_helpers.Gcf._set_new_active_manager(mgr)
             plt.draw_if_interactive()
+
+        self._original_dpi = original_dpi
 
         self.stale = True
 

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -217,6 +217,25 @@ def test_unpickle_canvas():
     assert fig2.canvas is not None
 
 
+def test_hidpi_pickle_unpickle_does_not_double_dpi():
+    fig = plt.figure(dpi=100)
+
+    fig.canvas._set_device_pixel_ratio(2)
+    assert fig.dpi == pytest.approx(200)
+    assert getattr(fig, "_original_dpi", None) == pytest.approx(100)
+
+    buffer = BytesIO()
+    pickle.dump(fig, buffer, pickle.HIGHEST_PROTOCOL)
+    buffer.seek(0)
+
+    restored = pickle.load(buffer)
+    assert restored.dpi == pytest.approx(200)
+
+    restored.canvas._set_device_pixel_ratio(2)
+    assert restored.dpi == pytest.approx(200)
+    assert getattr(restored, "_original_dpi", None) == pytest.approx(100)
+
+
 def test_mpl_toolkits():
     ax = parasite_axes.host_axes([0, 0, 1, 1])
     assert type(pickle.loads(pickle.dumps(ax))) == parasite_axes.HostAxes


### PR DESCRIPTION
## Summary
- preserve the figure's original DPI when restoring pickled figures
- reapply the stored DPI after recreating pyplot managers
- add a HiDPI pickle/unpickle regression test

## Testing
============================= test session starts ==============================
platform linux -- Python 3.10.19, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/matplotlib
configfile: pytest.ini
plugins: timeout-2.4.0, rerunfailures-16.1, xvfb-3.1.1, cov-7.0.0, xdist-3.8.0
collected 183 items

lib/matplotlib/tests/test_pickle.py .................................... [ 19%]
........................................................................ [ 59%]
........................................................................ [ 98%]
...                                                                      [100%]

============================= 183 passed in 1.44s ==============================

swev-id: matplotlib__matplotlib-23476

Closes #28
