### PR TITLE
Fix: Axes.bar StopIteration on all-NaN x (regression) — swev-id: matplotlib__matplotlib-24149

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2180,11 +2180,15 @@ class Axes(_AxesBase):
             # wrap numpy arrays.
             try:
                 x0 = cbook._safe_first_finite(x0)
+            except StopIteration:
+                x0 = cbook.safe_first_element(x0)
             except (TypeError, IndexError, KeyError):
                 pass
 
             try:
                 x = cbook._safe_first_finite(xconv)
+            except StopIteration:
+                x = cbook.safe_first_element(xconv)
             except (TypeError, IndexError, KeyError):
                 x = xconv
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8195,3 +8195,45 @@ def test_bar_leading_nan():
         for b in rest:
             assert np.isfinite(b.xy).all()
             assert np.isfinite(b.get_width())
+
+
+def test_bar_all_nan_x_and_height_no_stopiteration():
+    # Regression for Task 268 — matplotlib__matplotlib-24149.
+    fig, ax = plt.subplots()
+
+    container = ax.bar([np.nan], [np.nan])
+
+    plt.close(fig)
+
+    assert len(container) == 1
+    rect, = container
+    assert np.isnan(rect.get_x())
+    assert np.isnan(rect.get_height())
+
+
+def test_bar_nan_x_zero_height_no_stopiteration():
+    # Regression for Task 268 — matplotlib__matplotlib-24149.
+    fig, ax = plt.subplots()
+
+    container = ax.bar([np.nan], [0])
+
+    plt.close(fig)
+
+    assert len(container) == 1
+    rect, = container
+    assert np.isnan(rect.get_x())
+    assert rect.get_height() == 0
+
+
+def test_bar_zero_x_nan_height_baseline_ok():
+    # Regression for Task 268 — matplotlib__matplotlib-24149.
+    fig, ax = plt.subplots()
+
+    container = ax.bar([0], [np.nan])
+
+    plt.close(fig)
+
+    assert len(container) == 1
+    rect, = container
+    assert rect.get_x() == -0.4
+    assert np.isnan(rect.get_height())


### PR DESCRIPTION
## Summary
- fall back to safe_first_element when _safe_first_finite raises StopIteration in Axes._convert_dx
- add regression coverage for NaN-only bar inputs

## Testing


Resolves #34