### PR TITLE
swev-id: matplotlib__matplotlib-23412 — Honor dash offset for Patch edges

### DIFF
--- a/doc/users/next_whats_new/patch_dashoffset.rst
+++ b/doc/users/next_whats_new/patch_dashoffset.rst
@@ -1,0 +1,6 @@
+Patch dash offsets honored on patches
+-------------------------------------
+
+Patches now respect the dash offset specified via
+`~matplotlib.patches.Patch.set_linestyle`, so edge stroking matches the
+behaviour of lines across both vector (e.g. SVG) and raster (Agg) backends.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -588,7 +588,7 @@ class Patch(artist.Artist):
         # docstring inherited
         if not self.get_visible():
             return
-        # Patch has traditionally ignored the dashoffset.
+        # Preserve the computed dash offset via the bound draw_path.
         with self._bind_draw_path_function(renderer) as draw_path:
             path = self.get_path()
             transform = self.get_transform()

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -414,6 +414,8 @@ class Patch(artist.Artist):
             (offset, onoffseq)
 
         where ``onoffseq`` is an even length tuple of on and off ink in points.
+        When ``rcParams['lines.scale_dashes']`` is True (the default), both the
+        offset and the on/off lengths are scaled by the linewidth.
 
         Parameters
         ----------
@@ -587,9 +589,7 @@ class Patch(artist.Artist):
         if not self.get_visible():
             return
         # Patch has traditionally ignored the dashoffset.
-        with cbook._setattr_cm(
-                 self, _dash_pattern=(0, self._dash_pattern[1])), \
-             self._bind_draw_path_function(renderer) as draw_path:
+        with self._bind_draw_path_function(renderer) as draw_path:
             path = self.get_path()
             transform = self.get_transform()
             tpath = transform.transform_path_non_affine(path)

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -1,16 +1,22 @@
 """
 Tests specific to the patches module.
 """
+import io
+import re
+
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
 import matplotlib as mpl
+from matplotlib.backends.backend_agg import RendererAgg
+from matplotlib.backends.backend_svg import FigureCanvasSVG
 from matplotlib.patches import (Annulus, Ellipse, Patch, Polygon, Rectangle,
                                 FancyArrowPatch, FancyArrow, BoxStyle)
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.transforms import Bbox
 import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
 from matplotlib import (
     collections as mcollections, colors as mcolors, patches as mpatches,
     path as mpath, transforms as mtransforms, rcParams)
@@ -335,6 +341,59 @@ def test_patch_linestyle_none(fig_test, fig_ref):
     ax_test.set_ylim([-1, i + 1])
     ax_ref.set_xlim([-1, i + 1])
     ax_ref.set_ylim([-1, i + 1])
+
+
+def test_patch_linestyle_respects_dashoffset_svg():
+    fig = Figure(figsize=(2, 1))
+    ax = fig.add_subplot()
+    ax.set_axis_off()
+    ax.set_xlim(0, 3)
+    ax.set_ylim(0, 1)
+
+    rect_no_offset = Rectangle(
+        (0.1, 0.1), 1, 0.8, fill=False, linewidth=2,
+        linestyle=(0, (3, 2)))
+    rect_with_offset = Rectangle(
+        (1.5, 0.1), 1, 0.8, fill=False, linewidth=2,
+        linestyle=(6, (3, 2)))
+
+    ax.add_patch(rect_no_offset)
+    ax.add_patch(rect_with_offset)
+
+    canvas = FigureCanvasSVG(fig)
+    buffer = io.StringIO()
+    canvas.print_svg(buffer)
+    svg = buffer.getvalue()
+
+    offsets = [
+        float(match)
+        for match in re.findall(r"stroke-dashoffset:\s*([0-9.]+)", svg)
+    ]
+
+    assert len(offsets) >= 2
+    assert rect_no_offset._dash_pattern[0] == 0
+    assert offsets.count(rect_no_offset._dash_pattern[0]) >= 1
+    assert offsets.count(rect_with_offset._dash_pattern[0]) >= 1
+
+
+def test_patch_linestyle_dashoffset_prop_agg(monkeypatch):
+    renderer = RendererAgg(200, 200, 72)
+    rect = Rectangle(
+        (0, 0), 1, 1, fill=False, linewidth=2,
+        linestyle=(6, (3, 2)))
+
+    recorded = []
+    original_draw_path = RendererAgg.draw_path
+
+    def capture(self, gc, path, transform, rgbFace=None):
+        recorded.append(gc.get_dashes())
+        return original_draw_path(self, gc, path, transform, rgbFace)
+
+    monkeypatch.setattr(RendererAgg, "draw_path", capture)
+    rect.draw(renderer)
+
+    assert recorded
+    assert rect._dash_pattern in recorded
 
 
 def test_wedge_movement():


### PR DESCRIPTION
## Summary
- add regression coverage ensuring patch dash offsets propagate to SVG and Agg renders
- let Patch.draw forward its computed dash offset and document linewidth scaling
- note the behaviour change in the next what's new for patches

## Testing
- MPLBACKEND=Agg .venv/bin/pytest lib/matplotlib/tests/test_patches.py::test_patch_linestyle_respects_dashoffset_svg lib/matplotlib/tests/test_patch_linestyle_dashoffset_prop_agg
- .venv/bin/flake8 lib/matplotlib/tests/test_patches.py

Closes #30