### PR TITLE
swev-id: matplotlib__matplotlib-24570 fix HPacker top/bottom alignment

### DIFF
--- a/doc/api/next_api_changes/behavior/24570-EG.rst
+++ b/doc/api/next_api_changes/behavior/24570-EG.rst
@@ -1,0 +1,7 @@
+HPacker top and bottom alignment now flush the expected edges
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`matplotlib.offsetbox.HPacker` now aligns child boxes correctly when
+``align='top'`` or ``align='bottom'``. Top alignment keeps the top edges flush
+and bottom alignment keeps the bottom edges flush; previously the semantics
+were reversed. This is treated as a bug fix.

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -166,10 +166,10 @@ def _get_aligned_offsets(hd_list, height, align="baseline"):
         descent = max(d for h, d in hd_list)
         height = height_descent + descent
         offsets = [0. for h, d in hd_list]
-    elif align in ["left", "top"]:
+    elif align in ["left", "bottom"]:
         descent = 0.
         offsets = [d for h, d in hd_list]
-    elif align in ["right", "bottom"]:
+    elif align in ["right", "top"]:
         descent = 0.
         offsets = [height - h + d for h, d in hd_list]
     elif align == "center":
@@ -459,7 +459,8 @@ class VPacker(PackerBase):
 class HPacker(PackerBase):
     """
     HPacker packs its children horizontally, automatically adjusting their
-    relative positions at draw time.
+    relative positions at draw time. ``align='top'`` keeps the children's top
+    edges flush, while ``align='bottom'`` keeps their bottom edges flush.
     """
 
     def get_extent_offsets(self, renderer):

--- a/lib/matplotlib/tests/test_offsetbox_alignment.py
+++ b/lib/matplotlib/tests/test_offsetbox_alignment.py
@@ -1,0 +1,73 @@
+import pytest
+
+from matplotlib.offsetbox import DrawingArea, HPacker, VPacker
+
+
+class _UnitRenderer:
+    def points_to_pixels(self, points):
+        return points
+
+
+@pytest.fixture()
+def renderer():
+    return _UnitRenderer()
+
+
+def _y_offsets(offsets):
+    return [y for _, y in offsets]
+
+
+def _x_offsets(offsets):
+    return [x for x, _ in offsets]
+
+
+def test_hpacker_top_bottom(renderer):
+    short = DrawingArea(1, 10)
+    tall = DrawingArea(1, 30)
+
+    pack_top = HPacker(children=[short, tall], align="top", pad=0., sep=0.)
+    *_top, offsets_top = pack_top.get_extent_offsets(renderer)
+    assert _y_offsets(offsets_top) == [20, 0]
+
+    pack_bottom = HPacker(children=[DrawingArea(1, 10), DrawingArea(1, 30)],
+                          align="bottom", pad=0., sep=0.)
+    *_bottom, offsets_bottom = pack_bottom.get_extent_offsets(renderer)
+    assert _y_offsets(offsets_bottom) == [0, 0]
+
+
+def test_hpacker_center(renderer):
+    short = DrawingArea(1, 10)
+    tall = DrawingArea(1, 30)
+    pack_center = HPacker(children=[short, tall], align="center",
+                          pad=0., sep=0.)
+    *_center, offsets_center = pack_center.get_extent_offsets(renderer)
+    assert _y_offsets(offsets_center) == [10, 0]
+
+
+def test_hpacker_baseline_descent(renderer):
+    descender = DrawingArea(1, 10, ydescent=5)
+    baseline = DrawingArea(1, 20, ydescent=0)
+    pack_baseline = HPacker(children=[descender, baseline], align="baseline",
+                            pad=0., sep=0.)
+
+    width, height, xdescent, ydescent, offsets = (
+        pack_baseline.get_extent_offsets(renderer))
+
+    assert height == pytest.approx(25)
+    assert ydescent == pytest.approx(5)
+    assert _y_offsets(offsets) == [0, 0]
+
+
+def test_vpacker_left_right(renderer):
+    narrow = DrawingArea(10, 1)
+    wide = DrawingArea(30, 1)
+
+    pack_left = VPacker(children=[narrow, wide], align="left",
+                         pad=0., sep=0.)
+    *_left, offsets_left = pack_left.get_extent_offsets(renderer)
+    assert _x_offsets(offsets_left) == [0, 0]
+
+    pack_right = VPacker(children=[DrawingArea(10, 1), DrawingArea(30, 1)],
+                          align="right", pad=0., sep=0.)
+    *_right, offsets_right = pack_right.get_extent_offsets(renderer)
+    assert _x_offsets(offsets_right) == [20, 0]


### PR DESCRIPTION
## Reproduction steps
1. Use the script from #38 (reproduced below) and set `align="bottom"` or `align="top"` on the `HPacker`.
```python
import matplotlib.pyplot as plt
from matplotlib.offsetbox import DrawingArea, HPacker, VPacker, AnchoredOffsetbox, TextArea
from matplotlib.patches import Rectangle


da1 = DrawingArea(10, 20)
rect1 = Rectangle((0, 0), 10, 20)
da1.add_artist(rect1)

da2 = DrawingArea(10, 30)
rect2 = Rectangle((0, 0), 10, 30)
da2.add_artist(rect2)

align = "bottom"

pack = HPacker(children=[da1, da2], pad=10, sep=10, align=align)
title = TextArea(f"align='{align}'")
pack = VPacker(children=[title, pack], sep=10, pad=10, align="center")

box = AnchoredOffsetbox(child=pack, loc="center")

_, ax = plt.subplots()
ax.add_artist(box)
```

## Observed failure
- `align='bottom'` aligns the top edges and `align='top'` aligns the bottom edges, so the visual result is inverted relative to the API contract.

## Expected behavior
- `align='top'` should flush the children's top edges and `align='bottom'` should flush their bottom edges.

## Summary of changes
- Swap the `HPacker` top/bottom mapping in `_get_aligned_offsets` so offsets make top alignment flush the top edges and bottom alignment flush the bottom edges.
- Clarify the `HPacker` docstring and add geometry-based regression tests that cover top, bottom, center, and baseline alignment along with a `VPacker` left/right sanity check.
- Add a behavior release note fragment describing the bugfix.

## Testing
- `pytest -k offsetbox`
- `flake8 lib/matplotlib/offsetbox.py lib/matplotlib/tests/test_offsetbox_alignment.py`

Fixes #38.