### PR TITLE
swev-id: matplotlib__matplotlib-24637: Propagate gid for AnnotationBbox via renderer group (Task 272)

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1452,6 +1452,7 @@ or callable, default: value of *xycoords*
             self._renderer = renderer
         if not self.get_visible() or not self._check_xy(renderer):
             return
+        renderer.open_group('annotationbbox', gid=self.get_gid())
         self.update_positions(renderer)
         if self.arrow_patch is not None:
             if self.arrow_patch.figure is None and self.figure is not None:
@@ -1459,6 +1460,7 @@ or callable, default: value of *xycoords*
             self.arrow_patch.draw(renderer)
         self.patch.draw(renderer)
         self.offsetbox.draw(renderer)
+        renderer.close_group('annotationbbox')
         self.stale = False
 
 

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -550,6 +550,25 @@ def test_svg_escape():
         assert '&lt;&apos;&quot;&amp;&gt;"' in buf
 
 
+def test_annotationbbox_gid_svg():
+    fig, ax = plt.subplots()
+    text_box = mpl.offsetbox.TextArea("Annotation")
+    ab = mpl.offsetbox.AnnotationBbox(text_box, (0.5, 0.5))
+    ab.set_gid("ab_gid_test")
+    ax.add_artist(ab)
+
+    with BytesIO() as fd:
+        fig.savefig(fd, format='svg')
+        svg_bytes = fd.getvalue()
+
+    tree = xml.etree.ElementTree.fromstring(svg_bytes)
+    ns = "http://www.w3.org/2000/svg"
+    group = tree.find(f'.//{{{ns}}}g[@id="ab_gid_test"]')
+
+    assert group is not None
+    assert list(group), "AnnotationBbox group should contain drawn elements"
+
+
 @pytest.mark.parametrize("font_str", [
     "'DejaVu Sans', 'WenQuanYi Zen Hei', 'Arial', sans-serif",
     "'DejaVu Serif', 'WenQuanYi Zen Hei', 'Times New Roman', serif",


### PR DESCRIPTION
## Summary
- wrap `AnnotationBbox.draw` in a renderer group so `gid` propagates to backends
- close the renderer group after drawing the arrow, patch, and offsetbox content
- add an SVG regression test asserting `<g id>` emission for `AnnotationBbox`

## Reproduction
### Before
1. Create an `AnnotationBbox` with a `gid`, save the figure as SVG, and inspect the markup.
2. The annotation renders without an enclosing `<g id="...">`, so downstream selection fails.

### After
1. Repeat the steps above.
2. The SVG output now contains `<g id="ab_gid_test">` wrapping the annotation content.

## Testing
- `LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib MPLBACKEND=Agg .venv/bin/pytest lib/matplotlib/tests/test_backend_svg.py::test_annotationbbox_gid_svg`

Fixes #44