### PR TITLE
swev-id: matplotlib__matplotlib-24627 - detach artist parents after cla/clf

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1307,6 +1307,15 @@ class _AxesBase(martist.Artist):
         self._get_lines = _process_plot_var_args(self)
         self._get_patches_for_fill = _process_plot_var_args(self, 'fill')
 
+        legend = getattr(self, "legend_", None)
+        if legend is not None:
+            legend.remove()
+
+        for child in list(getattr(self, "_children", ())):
+            if child is legend:
+                continue
+            child.remove()
+
         self._gridOn = mpl.rcParams['axes.grid']
         self._children = []
         self._mouseover_set = _OrderedSet()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -947,7 +947,19 @@ default: %(va)s
 
         for ax in tuple(self.axes):  # Iterate over the copy.
             ax.clear()
-            self.delaxes(ax)  # Remove ax from self._axstack.
+            ax.remove()
+
+        for artist_list in (
+                self.artists,
+                self.lines,
+                self.patches,
+                self.texts,
+                self.images,
+                self.legends):
+            for artist in list(artist_list):
+                artist.remove()
+                if getattr(artist, "figure", None) is not None:
+                    artist.figure = None
 
         self.artists = []
         self.lines = []

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -214,6 +214,41 @@ def test_remove():
     assert ax.stale
 
 
+@pytest.mark.backend("Agg")
+def test_cla_unsets_artist_axes():
+    fig, ax = plt.subplots()
+    line, = ax.plot([0, 1], [0, 1])
+    patch = ax.add_patch(mpatches.Rectangle((0, 0), 1, 1))
+    image = ax.imshow(np.arange(4).reshape(2, 2))
+    text = ax.text(0.5, 0.5, "hi")
+    collection = ax.scatter([0], [0])
+    legend = ax.legend([line], ["line"])
+
+    ax.cla()
+
+    for artist in (line, patch, image, text, collection, legend):
+        assert artist.axes is None
+
+
+@pytest.mark.backend("Agg")
+def test_clf_unsets_figure_and_axes_parents():
+    fig, ax = plt.subplots()
+    line, = ax.plot([0, 1], [0, 1])
+    image = ax.imshow(np.arange(4).reshape(2, 2))
+    fig_text = fig.text(0.5, 0.5, "hi")
+    fig_legend = fig.legend([line], ["line"])
+    colorbar = fig.colorbar(image, ax=ax)
+
+    fig.clf()
+
+    assert fig.axes == []
+    assert line.axes is None
+    assert image.axes is None
+    assert fig_text.figure is None
+    assert fig_legend.figure is None
+    assert colorbar.ax.figure is None
+
+
 @image_comparison(["default_edges.png"], remove_text=True, style='default')
 def test_default_edges():
     # Remove this line when this test image is regenerated.


### PR DESCRIPTION
## Summary
- ensure `Axes.clear()` removes child artists via `remove()` so previously attached artists drop their `axes`
- update `Figure.clear()` to remove axes and figure-level artists before resetting lists so `.axes`/`.figure` references are cleared
- add Agg regression tests for `cla()` and `clf()` covering legends, images, and a colorbar-backed axes

## Observed failure (before fix)
```
============================= test session starts ==============================
platform linux -- Python 3.10.19, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/matplotlib
configfile: pytest.ini
plugins: timeout-2.4.0, rerunfailures-16.1, xvfb-3.1.1, cov-7.0.0, xdist-3.8.0
collected 2 items

lib/matplotlib/tests/test_artist.py FF                                   [100%]

=================================== FAILURES ===================================
_________________________ test_cla_unsets_artist_axes __________________________

    @pytest.mark.backend("Agg")
    def test_cla_unsets_artist_axes():
        fig, ax = plt.subplots()
        line, = ax.plot([0, 1], [0, 1])
        patch = ax.add_patch(mpatches.Rectangle((0, 0), 1, 1))
        image = ax.imshow(np.arange(4).reshape(2, 2))
        text = ax.text(0.5, 0.5, "hi")
        collection = ax.scatter([0], [0])
        legend = ax.legend([line], ["line"])
    
        ax.cla()
    
        for artist in (line, patch, image, text, collection, legend):
>           assert artist.axes is None
E           assert <Axes: > is None
E            +  where <Axes: > = <matplotlib.lines.Line2D object at 0xffff55daeb60>.axes

lib/matplotlib/tests/test_artist.py:215: AssertionError
------------------------------ Captured log setup ------------------------------
WARNING  matplotlib.testing:__init__.py:38 Could not set locale to English/United States. Some date-related tests may fail.
___________________ test_clf_unsets_figure_and_axes_parents ____________________

    @pytest.mark.backend("Agg")
    def test_clf_unsets_figure_and_axes_parents():
        fig, ax = plt.subplots()
        line, = ax.plot([0, 1], [0, 1])
        image = ax.imshow(np.arange(4).reshape(2, 2))
        fig_text = fig.text(0.5, 0.5, "hi")
        fig_legend = fig.legend([line], ["line"])
        colorbar = fig.colorbar(image, ax=ax)
    
        fig.clf()
    
        assert fig.axes == []
>       assert line.axes is None
E       assert <Axes: > is None
E        +  where <Axes: > = <matplotlib.lines.Line2D object at 0xffff553afd60>.axes

lib/matplotlib/tests/test_artist.py:230: AssertionError
------------------------------ Captured log setup ------------------------------
WARNING  matplotlib.testing:__init__.py:38 Could not set locale to English/United States. Some date-related tests may fail.
=========================== short test summary info ============================
FAILED lib/matplotlib/tests/test_artist.py::test_cla_unsets_artist_axes - ass...
FAILED lib/matplotlib/tests/test_artist.py::test_clf_unsets_figure_and_axes_parents
============================== 2 failed in 1.12s ===============================
```

## Reproduction
```python
import numpy as np
import matplotlib
matplotlib.use("Agg")
from matplotlib import pyplot as plt
from matplotlib import patches

fig, ax = plt.subplots()
line, = ax.plot([0, 1], [0, 1])
rect = patches.Rectangle((0, 0), 1, 1)
ax.add_patch(rect)
legend = ax.legend([line], ["line"])
ax.cla()
assert line.axes is None
assert rect.axes is None
assert legend.axes is None

fig, ax = plt.subplots()
line, = ax.plot([0, 1], [0, 1])
im = ax.imshow(np.arange(4).reshape(2, 2))
fig_text = fig.text(0.5, 0.5, "hi")
fig_legend = fig.legend([line], ["line"])
colorbar = fig.colorbar(im, ax=ax)
fig.clf()
assert fig.axes == []
assert line.axes is None
assert fig_text.figure is None
assert fig_legend.figure is None
assert colorbar.ax.figure is None
```

## Edge Cases & Verification
- Handles legends, containers, and colorbar axes so deparented artists drop `.axes`/`.figure` references.
- Tests: `LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib:/nix/store/62yvg9afjvmwa8z17arn4giqmjzg2xd2-glibc-2.40-66/lib PYTHONPATH=/workspace/matplotlib/lib MPLBACKEND=Agg .venv/bin/pytest lib/matplotlib/tests/test_artist.py::test_cla_unsets_artist_axes lib/matplotlib/tests/test_artist.py::test_clf_unsets_figure_and_axes_parents`
- Lint: `.venv/bin/flake8 lib/matplotlib/axes/_base.py lib/matplotlib/figure.py lib/matplotlib/tests/test_artist.py`