### PR TITLE
fix(axis): respect offset text labelcolor (swev-id: matplotlib__matplotlib-25287)

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2249,13 +2249,16 @@ class XAxis(Axis):
         )
         self.label_position = 'bottom'
 
+        labelcolor = mpl.rcParams['xtick.labelcolor']
+        offset_color = (labelcolor if labelcolor != 'inherit'
+                        else mpl.rcParams['xtick.color'])
         self.offsetText.set(
             x=1, y=0,
             verticalalignment='top', horizontalalignment='right',
             transform=mtransforms.blended_transform_factory(
                 self.axes.transAxes, mtransforms.IdentityTransform()),
             fontsize=mpl.rcParams['xtick.labelsize'],
-            color=mpl.rcParams['xtick.color'],
+            color=offset_color,
         )
         self.offset_text_position = 'bottom'
 
@@ -2509,13 +2512,16 @@ class YAxis(Axis):
         )
         self.label_position = 'left'
         # x in axes coords, y in display coords(!).
+        labelcolor = mpl.rcParams['ytick.labelcolor']
+        offset_color = (labelcolor if labelcolor != 'inherit'
+                        else mpl.rcParams['ytick.color'])
         self.offsetText.set(
             x=0, y=0.5,
             verticalalignment='baseline', horizontalalignment='left',
             transform=mtransforms.blended_transform_factory(
                 self.axes.transAxes, mtransforms.IdentityTransform()),
             fontsize=mpl.rcParams['ytick.labelsize'],
-            color=mpl.rcParams['ytick.color'],
+            color=offset_color,
         )
         self.offset_text_position = 'left'
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6068,6 +6068,80 @@ def test_move_offsetlabel():
     assert ax.xaxis.offsetText.get_verticalalignment() == 'bottom'
 
 
+def _axes_with_scientific_offsets():
+    fig, ax = plt.subplots()
+    x = np.linspace(1e10, 1e10 + 1, 3)
+    y = np.linspace(1e12, 1e12 + 1, 3)
+    ax.plot(x, y)
+    ax.ticklabel_format(style='sci', axis='both', scilimits=(0, 0))
+    fig.canvas.draw()
+    assert ax.xaxis.offsetText.get_text()
+    assert ax.yaxis.offsetText.get_text()
+    return fig, ax
+
+
+def test_offset_text_uses_labelcolor_from_rc():
+    rc = {
+        'xtick.labelcolor': 'red',
+        'ytick.labelcolor': 'green',
+        'xtick.color': 'black',
+        'ytick.color': 'black',
+    }
+    with matplotlib.rc_context(rc):
+        fig, ax = _axes_with_scientific_offsets()
+        try:
+            assert (
+                mcolors.to_rgba(ax.xaxis.offsetText.get_color())
+                == mcolors.to_rgba('red')
+            )
+            assert (
+                mcolors.to_rgba(ax.yaxis.offsetText.get_color())
+                == mcolors.to_rgba('green')
+            )
+        finally:
+            plt.close(fig)
+
+
+def test_offset_text_inherits_tick_color_when_labelcolor_inherit():
+    rc = {
+        'xtick.labelcolor': 'inherit',
+        'ytick.labelcolor': 'inherit',
+        'xtick.color': 'blue',
+        'ytick.color': 'magenta',
+    }
+    with matplotlib.rc_context(rc):
+        fig, ax = _axes_with_scientific_offsets()
+        try:
+            assert (
+                mcolors.to_rgba(ax.xaxis.offsetText.get_color())
+                == mcolors.to_rgba('blue')
+            )
+            assert (
+                mcolors.to_rgba(ax.yaxis.offsetText.get_color())
+                == mcolors.to_rgba('magenta')
+            )
+        finally:
+            plt.close(fig)
+
+
+def test_offset_text_follows_tick_params_labelcolor():
+    fig, ax = _axes_with_scientific_offsets()
+    try:
+        ax.tick_params(axis='x', labelcolor='purple')
+        ax.tick_params(axis='y', labelcolor='orange')
+        fig.canvas.draw()
+        assert (
+            mcolors.to_rgba(ax.xaxis.offsetText.get_color())
+            == mcolors.to_rgba('purple')
+        )
+        assert (
+            mcolors.to_rgba(ax.yaxis.offsetText.get_color())
+            == mcolors.to_rgba('orange')
+        )
+    finally:
+        plt.close(fig)
+
+
 @image_comparison(['rc_spines.png'], savefig_kwarg={'dpi': 40})
 def test_rc_spines():
     rc_dict = {


### PR DESCRIPTION
## Summary
- ensure `XAxis`/`YAxis` offset text inherits `tick.labelcolor` unless it is set to `inherit`
- fall back to `tick.color` when label color is inherited
- add regression tests covering rcParam overrides, inherit fallback, and `tick_params(labelcolor=...)`

## Issue
- closes #51

## Reproduction Steps
1. Checkout `matplotlib__matplotlib-25287`
2. Set up the test environment (venv + LD_LIBRARY_PATH as described in project docs)
3. Run:
   ```bash
   MPLBACKEND=Agg \
   PYTHONPATH=$(pwd)/lib \
   LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib \
   .venv/bin/pytest lib/matplotlib/tests/test_axes.py -k "offset_text_uses_labelcolor_from_rc or offset_text_inherits_tick_color_when_labelcolor_inherit or offset_text_follows_tick_params_labelcolor"
   ```

## Failing Test Output (before fix)
```
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/matplotlib
configfile: pytest.ini
collected 855 items / 852 deselected / 3 selected

lib/matplotlib/tests/test_axes.py F..                                    [100%]

=================================== FAILURES ===================================
___________________ test_offset_text_uses_labelcolor_from_rc ___________________
>               assert mcolors.to_rgba(ax.xaxis.offsetText.get_color()) == \
                    mcolors.to_rgba('red')
E                   assert (0.0, 0.0, 0.0, 1.0) == (1.0, 0.0, 0.0, 1.0)
E                     At index 0 diff: 0.0 != 1.0
E                     Use -v to get more diff

lib/matplotlib/tests/test_axes.py:6093: AssertionError
=========================== short test summary info ============================
FAILED lib/matplotlib/tests/test_axes.py::test_offset_text_uses_labelcolor_from_rc
================= 1 failed, 2 passed, 852 deselected in 1.07s ==================
```

## Testing
- `MPLBACKEND=Agg PYTHONPATH=$(pwd)/lib LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest lib/matplotlib/tests/test_axes.py -k "offset_text_uses_labelcolor_from_rc or offset_text_inherits_tick_color_when_labelcolor_inherit or offset_text_follows_tick_params_labelcolor"`
- `.venv/bin/flake8 lib/matplotlib/axis.py`
- `.venv/bin/flake8 --extend-ignore=E721 lib/matplotlib/tests/test_axes.py`
