### PR TITLE
fix: ensure pyplot set_cmap handles registered keys (swev-id: matplotlib__matplotlib-25479)

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2278,13 +2278,16 @@ def set_cmap(cmap: Colormap | str) -> None:
     matplotlib.cm.register_cmap
     matplotlib.cm.get_cmap
     """
-    cmap = get_cmap(cmap)
+    cmap_obj = get_cmap(cmap)
 
-    rc('image', cmap=cmap.name)
+    if isinstance(cmap, str):
+        rc('image', cmap=cmap)
+    else:
+        rc('image', cmap=cmap_obj.name)
     im = gci()
 
     if im is not None:
-        im.set_cmap(cmap)
+        im.set_cmap(cmap_obj)
 
 
 @_copy_docstring_and_deprecators(matplotlib.image.imread)

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -9,6 +9,7 @@ import pytest
 import matplotlib as mpl
 from matplotlib.testing import subprocess_run_for_testing
 from matplotlib import pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
 
 
 def test_pyplot_up_to_date(tmpdir):
@@ -78,6 +79,37 @@ def test_pyplot_box():
 def test_stackplot_smoke():
     # Small smoke test for stackplot (see #12405)
     plt.stackplot([1, 2, 3], [1, 2, 3])
+
+
+def test_set_cmap_uses_registered_key_for_rcparams():
+    original_cmap = mpl.rcParams['image.cmap']
+    cmap = LinearSegmentedColormap.from_list(
+        'some_cmap_name', ['black', 'white']
+    )
+    mpl.colormaps.register(cmap, name='my_cmap_name', force=True)
+    try:
+        plt.set_cmap('my_cmap_name')
+        assert mpl.rcParams['image.cmap'] == 'my_cmap_name'
+        plt.imshow(np.arange(4).reshape(2, 2))
+    finally:
+        mpl.rcParams['image.cmap'] = original_cmap
+        mpl.colormaps.unregister('my_cmap_name')
+        plt.close('all')
+
+
+def test_set_cmap_colormap_object_rcparams_name_passthrough():
+    original_cmap = mpl.rcParams['image.cmap']
+    cmap = LinearSegmentedColormap.from_list(
+        'unregistered_internal_name', ['black', 'white']
+    )
+    mpl.colormaps.register(cmap, name='alias_for_object', force=True)
+    try:
+        plt.set_cmap(cmap)
+        assert mpl.rcParams['image.cmap'] == 'unregistered_internal_name'
+    finally:
+        mpl.rcParams['image.cmap'] = original_cmap
+        mpl.colormaps.unregister('alias_for_object')
+        plt.close('all')
 
 
 def test_nrows_error():


### PR DESCRIPTION
## Summary
- ensure `pyplot.set_cmap` stores the passed registry key when provided a string
- keep colormap-object inputs writing the object's intrinsic name
- add regression coverage for rcParams behavior with both string and object inputs

Fixes #58

## Testing
- MPLBACKEND=Agg PYTHONPATH=/workspace/matplotlib/lib LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib .venv/bin/pytest lib/matplotlib/tests/test_pyplot.py -k 'set_cmap_'
- .venv/bin/flake8 lib/matplotlib/pyplot.py lib/matplotlib/tests/test_pyplot.py

## Reproduction
Pre-fix script:
```python
import matplotlib as mpl
import matplotlib.pyplot as plt
import numpy as np
from matplotlib.colors import LinearSegmentedColormap

lsc = LinearSegmentedColormap.from_list('some_cmap_name', ['black', 'white'])
mpl.colormaps.register(lsc, name='my_cmap_name', force=True)
plt.set_cmap('my_cmap_name')
plt.imshow(np.arange(4).reshape(2, 2))
```
Observed failure (excerpt):
```
ValueError: 'some_cmap_name' is not a valid value for cmap; supported values are ... 'my_cmap_name', ...
  File ".../matplotlib/cm.py", line 722, in _ensure_cmap
    _api.check_in_list(sorted(_colormaps), cmap=cmap_name)
```
Post-fix confirmation:
```
imshow succeeded; rc image.cmap = my_cmap_name
```