### PR TITLE
swev-id: matplotlib__matplotlib-26113 — Align hexbin mincnt behavior with and without C (>= mincnt)

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5013,8 +5013,9 @@ default: :rc:`scatter.edgecolors`
                     Cs_at_i2[i2[i]].append(C[i])
             if mincnt is None:
                 mincnt = 1
+            threshold = max(mincnt, 1)
             accum = np.array(
-                [reduce_C_function(acc) if len(acc) >= mincnt else np.nan
+                [reduce_C_function(acc) if len(acc) >= threshold else np.nan
                  for Cs_at_i in [Cs_at_i1, Cs_at_i2]
                  for acc in Cs_at_i[1:]],  # [1:] drops out-of-range points.
                 float)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4847,8 +4847,8 @@ default: :rc:`scatter.edgecolors`
         yscale : {'linear', 'log'}, default: 'linear'
             Use a linear or log10 scale on the vertical axis.
 
-        mincnt : int > 0, default: *None*
-            If not *None*, only display cells with more than *mincnt*
+        mincnt : int >= 0, default: *None*
+            If not *None*, only display cells with at least *mincnt*
             number of points in the cell.
 
         marginals : bool, default: *False*
@@ -5012,9 +5012,9 @@ default: :rc:`scatter.edgecolors`
                 else:
                     Cs_at_i2[i2[i]].append(C[i])
             if mincnt is None:
-                mincnt = 0
+                mincnt = 1
             accum = np.array(
-                [reduce_C_function(acc) if len(acc) > mincnt else np.nan
+                [reduce_C_function(acc) if len(acc) >= mincnt else np.nan
                  for Cs_at_i in [Cs_at_i1, Cs_at_i2]
                  for acc in Cs_at_i[1:]],  # [1:] drops out-of-range points.
                 float)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -999,6 +999,40 @@ def test_hexbin_log_clim():
     assert h.get_clim() == (2, 100)
 
 
+def test_hexbin_mincnt_counts():
+    x = np.array([0.1, 1.6])
+    y = np.array([0.1, 1.6])
+    fig, ax = plt.subplots()
+    coll = ax.hexbin(
+        x, y, gridsize=(2, 2), extent=(0, 2, 0, 2), mincnt=1)
+    assert_array_equal(coll.get_array(), np.array([1.0, 1.0]))
+
+
+def test_hexbin_mincnt_with_C():
+    x = np.array([0.1, 1.6])
+    y = np.array([0.1, 1.6])
+    fig, ax = plt.subplots()
+    coll = ax.hexbin(
+        x, y, C=np.ones_like(x), gridsize=(2, 2), extent=(0, 2, 0, 2),
+        mincnt=1, reduce_C_function=np.sum)
+    assert_array_equal(coll.get_array(), np.array([1.0, 1.0]))
+
+
+def test_hexbin_mincnt_excludes_when_below_threshold():
+    x = np.array([0.1, 1.6])
+    y = np.array([0.1, 1.6])
+    fig, ax = plt.subplots()
+    counts = ax.hexbin(
+        x, y, gridsize=(2, 2), extent=(0, 2, 0, 2), mincnt=2)
+    assert len(counts.get_array()) == 0
+
+    fig, ax = plt.subplots()
+    reduced = ax.hexbin(
+        x, y, C=np.ones_like(x), gridsize=(2, 2), extent=(0, 2, 0, 2),
+        mincnt=2, reduce_C_function=np.sum)
+    assert len(reduced.get_array()) == 0
+
+
 def test_inverted_limits():
     # Test gh:1553
     # Calling invert_xaxis prior to plotting should not disable autoscaling

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1033,6 +1033,24 @@ def test_hexbin_mincnt_excludes_when_below_threshold():
     assert len(reduced.get_array()) == 0
 
 
+def test_hexbin_mincnt_zero_with_C_matches_default():
+    x = np.array([0.1, 1.6])
+    y = np.array([0.1, 1.6])
+    fig, ax = plt.subplots()
+    hb_zero = ax.hexbin(
+        x, y, C=np.ones_like(x), gridsize=(3, 3), extent=(0, 2, 0, 2),
+        mincnt=0, reduce_C_function=np.sum)
+
+    fig, ax = plt.subplots()
+    hb_default = ax.hexbin(
+        x, y, C=np.ones_like(x), gridsize=(3, 3), extent=(0, 2, 0, 2),
+        reduce_C_function=np.sum)
+
+    assert_array_equal(hb_zero.get_offsets(), hb_default.get_offsets())
+    assert_array_equal(hb_zero.get_array(), hb_default.get_array())
+    assert len(hb_zero.get_array()) == 2
+
+
 def test_inverted_limits():
     # Test gh:1553
     # Calling invert_xaxis prior to plotting should not disable autoscaling


### PR DESCRIPTION
## Summary
- set the `C`-aware hexbin path to treat `mincnt=None` as 1 and require `len(acc) >= mincnt`
- update the `mincnt` docstring to describe the \"at least\" threshold
- add focused regression tests covering parity between count- and `C`-based binning

## Issue
Fixes #63

## Reproduction
```python
import numpy as np
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
x = np.array([0.1, 1.6])
y = np.array([0.1, 1.6])

print(ax.hexbin(x, y, gridsize=(2, 2), extent=(0, 2, 0, 2), mincnt=1).get_array())
print(ax.hexbin(x, y, C=np.ones_like(x), gridsize=(2, 2), extent=(0, 2, 0, 2), mincnt=1, reduce_C_function=np.sum).get_array())
```

## Observed Behavior
- Without `C`, the bin counts were returned when population size was `>= mincnt`.
- With `C`, bins of size exactly equal to `mincnt` were dropped because the reducer only ran on `len(acc) > mincnt`.

## Expected Behavior
- Both code paths should emit bins whenever the population length meets or exceeds `mincnt`.

## Testing
- `MPLBACKEND=Agg PYTHONPATH=/workspace/matplotlib/lib LD_LIBRARY_PATH=/root/.nix-profile/lib .venv/bin/pytest -q lib/matplotlib/tests/test_axes.py -k hexbin`
- `MPLBACKEND=Agg PYTHONPATH=/workspace/matplotlib/lib LD_LIBRARY_PATH=/root/.nix-profile/lib .venv/bin/flake8 lib/matplotlib/axes/_axes.py lib/matplotlib/tests/test_axes.py --extend-ignore=E721`