### PR TITLE
swev-id: matplotlib__matplotlib-25960 honor subfigure spacing

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2274,17 +2274,30 @@ class SubFigure(FigureBase):
             return
         # need to figure out *where* this subplotspec is.
         gs = self._subplotspec.get_gridspec()
-        wr = np.asarray(gs.get_width_ratios())
-        hr = np.asarray(gs.get_height_ratios())
-        dx = wr[self._subplotspec.colspan].sum() / wr.sum()
-        dy = hr[self._subplotspec.rowspan].sum() / hr.sum()
-        x0 = wr[:self._subplotspec.colspan.start].sum() / wr.sum()
-        y0 = 1 - hr[:self._subplotspec.rowspan.stop].sum() / hr.sum()
+        wspace = gs.wspace if gs.wspace is not None else 0.0
+        hspace = gs.hspace if gs.hspace is not None else 0.0
+
+        subplotpars = SubplotParams(
+            left=0, right=1, bottom=0, top=1, wspace=wspace, hspace=hspace)
+        dummy_fig = type("_SubplotParamFig", (), {})()
+        dummy_fig.subplotpars = subplotpars
+
+        fig_bottoms, fig_tops, fig_lefts, fig_rights = gs.get_grid_positions(
+            dummy_fig)
+
+        col_span = self._subplotspec.colspan
+        row_span = self._subplotspec.rowspan
+
+        x0 = fig_lefts[col_span.start]
+        x1 = fig_rights[col_span.stop - 1]
+        y0 = fig_bottoms[row_span.stop - 1]
+        y1 = fig_tops[row_span.start]
+
         if self.bbox_relative is None:
-            self.bbox_relative = Bbox.from_bounds(x0, y0, dx, dy)
+            self.bbox_relative = Bbox.from_extents(x0, y0, x1, y1)
         else:
             self.bbox_relative.p0 = (x0, y0)
-            self.bbox_relative.p1 = (x0 + dx, y0 + dy)
+            self.bbox_relative.p1 = (x1, y1)
 
     def get_constrained_layout(self):
         """

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -302,6 +302,60 @@ def test_suptitle_subfigures():
     assert sf2.get_facecolor() == (1.0, 1.0, 1.0, 1.0)
 
 
+def test_subfigures_wspace_spacing():
+    fig = plt.figure()
+    try:
+        left, right = fig.subfigures(1, 2, wspace=0.2)
+
+        expected_gap = 0.2 / (2 + 0.2 * (2 - 1))
+        gap = right.bbox_relative.x0 - left.bbox_relative.x1
+
+        assert gap == pytest.approx(expected_gap)
+        assert left.bbox_relative.width == pytest.approx(right.bbox_relative.width)
+    finally:
+        plt.close(fig)
+
+
+def test_subfigures_hspace_spacing():
+    fig = plt.figure()
+    try:
+        top, bottom = fig.subfigures(2, 1, hspace=0.3)
+
+        expected_gap = 0.3 / (2 + 0.3 * (2 - 1))
+        gap = top.bbox_relative.y0 - bottom.bbox_relative.y1
+
+        assert gap == pytest.approx(expected_gap)
+        assert top.bbox_relative.height == pytest.approx(bottom.bbox_relative.height)
+    finally:
+        plt.close(fig)
+
+
+def test_subfigures_default_spacing_none():
+    fig = plt.figure()
+    try:
+        left, right = fig.subfigures(1, 2)
+
+        gap = right.bbox_relative.x0 - left.bbox_relative.x1
+
+        assert gap == pytest.approx(0.0)
+    finally:
+        plt.close(fig)
+
+
+def test_nested_subfigures_inherit_spacing():
+    fig = plt.figure()
+    try:
+        left, _ = fig.subfigures(1, 2, wspace=0.1)
+        top, bottom = left.subfigures(2, 1, hspace=0.25)
+
+        expected_gap = 0.25 / (2 + 0.25 * (2 - 1))
+        gap = top.bbox_relative.y0 - bottom.bbox_relative.y1
+
+        assert gap == pytest.approx(expected_gap)
+    finally:
+        plt.close(fig)
+
+
 def test_get_suptitle_supxlabel_supylabel():
     fig, ax = plt.subplots()
     assert fig.get_suptitle() == ""


### PR DESCRIPTION
## Summary
- implement subfigure bbox computation that honors explicit wspace/hspace in non-constrained layouts
- add geometry-based tests covering horizontal, vertical, default, and nested spacing
- ensure constrained layout path continues to rely on provided bboxes

## Testing
- pytest lib/matplotlib/tests/test_figure.py -k 'subfigures_wspace_spacing or subfigures_hspace_spacing or subfigures_default_spacing_none or nested_subfigures_inherit_spacing'
- pytest lib/matplotlib/tests/test_figure.py -k 'subfigure_spanning or subfigure_tightbbox' --maxfail=1
- flake8 lib/matplotlib/figure.py lib/matplotlib/tests/test_figure.py

## Issue
Fixes #64

## Reproduction Steps
1. From matplotlib__matplotlib-25960, run `pytest lib/matplotlib/tests/test_figure.py -k 'subfigures_wspace_spacing or subfigures_hspace_spacing or nested_subfigures_inherit_spacing'`

## Observed Failure (pre-fix)
```
============================= test session starts ==============================
platform linux -- Python 3.10.19, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/matplotlib
configfile: pytest.ini
plugins: timeout-2.4.0, rerunfailures-16.1, xvfb-3.1.1, cov-7.0.0, xdist-3.8.0
collected 148 items / 144 deselected / 4 selected

lib/matplotlib/tests/test_figure.py FF.F                                 [100%]

=================================== FAILURES ===================================
________________________ test_subfigures_wspace_spacing ________________________

    def test_subfigures_wspace_spacing():
        fig = plt.figure()
        left, right = fig.subfigures(1, 2, wspace=0.2)
    
        expected_gap = 0.2 / (2 + 0.2 * (2 - 1))
        gap = right.bbox_relative.x0 - left.bbox_relative.x1
    
>       assert gap == pytest.approx(expected_gap)
E       assert 0.0 == 0.09090909090909091 ± 9.1e-08
E         
E         comparison failed
E         Obtained: 0.0
E         Expected: 0.09090909090909091 ± 9.1e-08

lib/matplotlib/tests/test_figure.py:312: AssertionError
________________________ test_subfigures_hspace_spacing ________________________

    def test_subfigures_hspace_spacing():
        fig = plt.figure()
        top, bottom = fig.subfigures(2, 1, hspace=0.3)
    
        expected_gap = 0.3 / (2 + 0.3 * (2 - 1))
        gap = top.bbox_relative.y0 - bottom.bbox_relative.y1
    
>       assert gap == pytest.approx(expected_gap)
E       assert 0.0 == 0.13043478260869565 ± 1.3e-07
E         
E         comparison failed
E         Obtained: 0.0
E         Expected: 0.13043478260869565 ± 1.3e-07

lib/matplotlib/tests/test_figure.py:324: AssertionError
____________________ test_nested_subfigures_inherit_spacing ____________________

    def test_nested_subfigures_inherit_spacing():
        fig = plt.figure()
        left, _ = fig.subfigures(1, 2, wspace=0.1)
        top, bottom = left.subfigures(2, 1, hspace=0.25)
    
        expected_gap = 0.25 / (2 + 0.25 * (2 - 1))
        gap = top.bbox_relative.y0 - bottom.bbox_relative.y1
    
>       assert gap == pytest.approx(expected_gap)
E       assert 0.0 == 0.1111111111111111 ± 1.1e-07
E         
E         comparison failed
E         Obtained: 0.0
E         Expected: 0.1111111111111111 ± 1.1e-07

lib/matplotlib/tests/test_figure.py:347: AssertionError
=========================== short test summary info ============================
FAILED lib/matplotlib/tests/test_figure.py::test_subfigures_wspace_spacing - ...
FAILED lib/matplotlib/tests/test_figure.py::test_subfigures_hspace_spacing - ...
FAILED lib/matplotlib/tests/test_figure.py::test_nested_subfigures_inherit_spacing
================= 3 failed, 1 passed, 144 deselected in 0.32s ==================
```

## Fix
- SubFigure now delegates spacing-aware bbox calculation to GridSpec using a dummy SubplotParams so non-constrained wspace/hspace offsets create gaps while constrained layout keeps passing explicit bboxes.
- Added regression tests verifying non-constrained spacing works horizontally, vertically, and within nested subfigures, plus default spacing remains unchanged.