### PR TITLE
Fix inset locator renderer fallback (swev-id: matplotlib__matplotlib-26291)

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -69,6 +69,8 @@ class AnchoredLocatorBase(AnchoredOffsetbox):
         raise RuntimeError("No draw method should be called")
 
     def __call__(self, ax, renderer):
+        if renderer is None:
+            renderer = ax.figure._get_renderer()
         self.axes = ax
         bbox = self.get_window_extent(renderer)
         px, py = self.get_offset(bbox.width, bbox.height, 0, 0, renderer)

--- a/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from itertools import product
 import platform
 
@@ -117,6 +118,17 @@ def test_inset_colorbar_tight_layout_smoketest():
     with pytest.warns(UserWarning, match="This figure includes Axes"):
         # Will warn, but not raise an error
         plt.tight_layout()
+
+
+def test_inset_axes_tight_bbox_smoketest():
+    fig, (ax, ax2) = plt.subplots(1, 2, figsize=(5.5, 2.8))
+    try:
+        inset_axes(ax, width=1.3, height=0.9)
+        buffer = BytesIO()
+        fig.savefig(buffer, format="png", bbox_inches="tight")
+        assert buffer.getbuffer().nbytes > 0
+    finally:
+        plt.close(fig)
 
 
 @image_comparison(['inset_locator.png'], style='default', remove_text=True)


### PR DESCRIPTION
## Summary
- ensure `AnchoredLocatorBase.__call__` acquires a renderer if one was not provided
- prevent AttributeError when inline backend implicitly requests `bbox_inches='tight'`
- keep existing locator behavior otherwise unchanged

## Observed Failure
- `AttributeError: 'NoneType' object has no attribute '_get_renderer'` when `inset_axes` is used under the inline backend with tight bounding box rendering

## Reproduction
1. Run the inline smoketest snippet from Issue #67 to see the AttributeError
2. With this branch, rerun the same snippet and verify it completes and saves the figure
3. Confirm `Axes.inset_axes` still works with `bbox_inches='tight'`

Fixes #67