### PR TITLE
swev-id: matplotlib__matplotlib-26208 fix: reuse categorical unitdata on shared axes

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -102,6 +102,19 @@ class StrCategoryConverter(units.ConversionInterface):
         """
         # the conversion call stack is default_units -> axis_info -> convert
         if axis.units is None:
+            axis_name = axis.axis_name
+            shared_axes = axis.axes._shared_axes[axis_name].get_siblings(
+                axis.axes)
+            for shared in shared_axes:
+                if shared is axis.axes:
+                    continue
+                sibling_axis = shared._axis_map[axis_name]
+                if isinstance(sibling_axis.units, UnitData):
+                    axis.units = sibling_axis.units
+                    axis._update_axisinfo()
+                    break
+
+        if axis.units is None:
             axis.set_units(UnitData(data))
         else:
             axis.units.update(data)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -23,6 +23,7 @@ import matplotlib.colors as mcolors
 import matplotlib.dates as mdates
 from matplotlib.figure import Figure
 from matplotlib.axes import Axes
+from matplotlib.category import UnitData
 import matplotlib.font_manager as mfont_manager
 import matplotlib.markers as mmarkers
 import matplotlib.patches as mpatches
@@ -3034,6 +3035,67 @@ def test_stackplot_baseline():
     axs[0, 1].stackplot(range(100), d.T, baseline='sym')
     axs[1, 0].stackplot(range(100), d.T, baseline='wiggle')
     axs[1, 1].stackplot(range(100), d.T, baseline='weighted_wiggle')
+
+
+def _stackplot_sample_data():
+    x = ["16 May", "17 May"]
+    y1 = np.array([1, 2])
+    y2 = np.array([3, 1])
+    return x, y1, y2
+
+
+def test_stackplot_twinx_preserves_datalim():
+    fig, ax1 = plt.subplots()
+    x, y1, y2 = _stackplot_sample_data()
+    ax1.stackplot(x, y1, y2)
+    before = ax1.dataLim.intervaly
+
+    ax2 = ax1.twinx()
+    assert_allclose(ax1.dataLim.intervaly, before)
+
+    ax2.plot(x, [2, 4])
+    assert_allclose(ax1.dataLim.intervaly, before)
+
+
+def test_stackplot_twinx_reuses_unitdata():
+    fig, ax1 = plt.subplots()
+    x, y1, y2 = _stackplot_sample_data()
+    ax1.stackplot(x, y1, y2)
+
+    ax2 = ax1.twinx()
+    ax2.plot(x, [2, 4])
+
+    assert isinstance(ax1.xaxis.units, UnitData)
+    assert ax2.xaxis.units is ax1.xaxis.units
+
+
+def test_stackplot_twinx_numeric_x_units_none():
+    fig, ax1 = plt.subplots()
+    x = [0, 1]
+    y1 = np.array([1, 2])
+    y2 = np.array([3, 1])
+    ax1.stackplot(x, y1, y2)
+
+    ax2 = ax1.twinx()
+    ax2.plot(x, [2, 4])
+
+    assert ax1.xaxis.units is None
+    assert ax2.xaxis.units is None
+
+
+def test_stackplot_categorical_primary_axis_units():
+    fig, ax = plt.subplots()
+    x, y1, y2 = _stackplot_sample_data()
+    ax.stackplot(x, y1, y2)
+
+    assert isinstance(ax.xaxis.units, UnitData)
+
+    before = ax.dataLim.intervaly
+    ax.plot(x, [4, 5])
+    after = ax.dataLim.intervaly
+
+    assert after[0] <= before[0]
+    assert after[1] >= 5
 
 
 def _bxp_test_helper(


### PR DESCRIPTION
## Summary
- reuse `UnitData` from existing shared categorical axes to avoid triggering the units callback that clears the original `Axes.dataLim`
- update `StrCategoryConverter.default_units` to look up siblings before allocating a new `UnitData`
- add regression coverage for stackplot+twinx combinations plus numeric and categorical control cases

## Issue
Fixes #62

## Reproduction
```python
import matplotlib.pyplot as plt

def print_datalim(*ax):
    for ax_ in ax:
        print(ax_.dataLim.intervaly, end=' / ')
    print()

df1_index = ['16 May', '17 May']  # == df2_index
df1_values = [-22.717708333333402, 26.584999999999937]
df2_values = [-0.08501399999999998, -2.9833019999999966]

fig, ax1 = plt.subplots()

ax1.stackplot(df1_index, df1_values)
print_datalim(ax1)

ax2 = ax1.twinx()  # instantiate a second axes that shares the same x-axis
print_datalim(ax1, ax2)

ax2.plot(df1_index, df2_values)
print_datalim(ax1, ax2)
```

### Observed failure (pre-fix)
```
[-22.71770833  26.585     ] /
[-22.71770833  26.585     ] / [ inf -inf] /
[ inf -inf] / [-2.983302 -0.085014] /
```

## Environment
- Container: Ubuntu 22.04
- Python: 3.11.14 (nixpkgs#python311)
- Matplotlib built via `pip install -e . --config-settings editable_mode=compat --no-build-isolation`
- NumPy 1.26.4, pytest 9.0.2, flake8 7.3.0

## Testing
- `MPLBACKEND=Agg PYTHONPATH=/workspace/matplotlib/lib LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib PYTEST_ADDOPTS='-W ignore::DeprecationWarning' .venv/bin/pytest -q lib/matplotlib/tests/test_axes.py::test_stackplot_twinx_preserves_datalim`
- `MPLBACKEND=Agg PYTHONPATH=/workspace/matplotlib/lib LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib PYTEST_ADDOPTS='-W ignore::DeprecationWarning' .venv/bin/pytest -q lib/matplotlib/tests/test_axes.py::test_stackplot_twinx_reuses_unitdata`
- `MPLBACKEND=Agg PYTHONPATH=/workspace/matplotlib/lib LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib PYTEST_ADDOPTS='-W ignore::DeprecationWarning' .venv/bin/pytest -q lib/matplotlib/tests/test_axes.py::test_stackplot_twinx_numeric_x_units_none`
- `MPLBACKEND=Agg PYTHONPATH=/workspace/matplotlib/lib LD_LIBRARY_PATH=/root/.nix-profile/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib PYTEST_ADDOPTS='-W ignore::DeprecationWarning' .venv/bin/pytest -q lib/matplotlib/tests/test_axes.py::test_stackplot_categorical_primary_axis_units`
- `.venv/bin/flake8 lib/matplotlib/category.py`
- `.venv/bin/flake8 --extend-ignore=E721 lib/matplotlib/tests/test_axes.py`